### PR TITLE
Build normalized immutable Job Inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 | **Real parse view** | A "What the ATS sees" tab shows the exact plain text a parser extracts — if it reads cleanly there, it reads cleanly in Workday, Greenhouse, Lever, and iCIMS. |
 | **2026-aware scoring** | Semantic matching, no keyword stuffing (modern ATS penalize it), calibrated scores with the arithmetic explained — plus an instant, deterministic keyword scan that runs in your browser before any AI. |
 | **Local-first privacy** | Your profile and history live in your browser's localStorage. The app does not write a server-side copy. One click erases everything. |
+| **Job Inbox** | Save immutable, SHA-256-addressed posting snapshots; import CSV/JSON in bulk; skip duplicates by source ID, canonical URL, company/title/location, or description hash. |
 
 ## Features
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ import {
 import { ResultView } from "@/components/ResultView";
 import { Chip, Section, Spinner, ToolButton } from "@/components/ui";
 import { DictationButton } from "@/components/SpeechControls";
+import { JobInbox } from "@/components/JobInbox";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -534,6 +535,23 @@ export default function Home() {
             {notice && <p className="mt-2 text-xs text-warn">{notice}</p>}
           </Section>
         </div>
+
+        <JobInbox
+          current={{
+            company: company.trim() || "Unknown company",
+            title: jobTitle.trim() || "Untitled role",
+            description: jobText,
+            applicationUrl: jobUrl,
+          }}
+          onSelect={(job) => {
+            invalidateResult();
+            setJobText(job.description);
+            setJobUrl(job.applicationUrl);
+            setJobTitle(job.title);
+            setCompany(job.company);
+            setNotice(`Loaded immutable snapshot revision ${job.revision} from the Job Inbox.`);
+          }}
+        />
 
         {/* Instant scan */}
         {scan && (

--- a/components/JobInbox.tsx
+++ b/components/JobInbox.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { addJobSnapshot, createJobSnapshot, parseJobImport, type JobImportInput } from "@/lib/job-inbox";
+import type { JobPostingSnapshot } from "@/lib/schema";
+import { deleteJobSnapshot, loadJobInbox, saveJobInbox } from "@/lib/storage";
+import { ToolButton } from "@/components/ui";
+
+export function JobInbox({ current, onSelect }: { current: JobImportInput; onSelect: (job: JobPostingSnapshot) => void }) {
+  const [jobs, setJobs] = useState<JobPostingSnapshot[]>(() => loadJobInbox());
+  const [message, setMessage] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const cleared = () => { setJobs([]); setMessage("Job Inbox erased from this browser."); };
+    window.addEventListener("resume-foundry:data-cleared", cleared);
+    return () => window.removeEventListener("resume-foundry:data-cleared", cleared);
+  }, []);
+
+  async function addInputs(inputs: JobImportInput[]) {
+    let next = jobs, added = 0, duplicates = 0, rejected = 0;
+    for (const input of inputs) {
+      try {
+        const snapshot = await createJobSnapshot(input, next);
+        const result = addJobSnapshot(next, snapshot);
+        next = result.jobs;
+        if (result.added) added += 1;
+        else duplicates += 1;
+      } catch { rejected += 1; }
+    }
+    saveJobInbox(next); setJobs(next);
+    setMessage(`${added} imported · ${duplicates} duplicate${duplicates === 1 ? "" : "s"} skipped${rejected ? ` · ${rejected} invalid` : ""}`);
+  }
+
+  async function importFile(file: File) {
+    const format = file.name.toLowerCase().endsWith(".json") ? "json" : "csv";
+    try { await addInputs(parseJobImport(await file.text(), format)); }
+    catch (error) { setMessage(error instanceof Error ? error.message : "Import failed."); }
+  }
+
+  return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="job-inbox-heading">
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div><h2 id="job-inbox-heading" className="font-display text-xl font-semibold text-paper">Job Inbox</h2><p className="text-[11px] text-ink-400">Immutable posting snapshots stored only in this browser.</p></div>
+      <div className="flex flex-wrap gap-2">
+        <ToolButton onClick={() => void addInputs([{ ...current, source: current.applicationUrl ? "url" : "manual" }])}>Save current job</ToolButton>
+        <ToolButton onClick={() => fileRef.current?.click()}>Import CSV/JSON</ToolButton>
+        <input ref={fileRef} className="sr-only" type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => { const file = event.target.files?.[0]; if (file) void importFile(file); event.target.value = ""; }} />
+      </div>
+    </div>
+    {message && <p role="status" className="mt-2 text-xs text-brass-300">{message}</p>}
+    {jobs.length === 0 ? <p className="mt-3 rounded-lg border border-dashed border-ink-700 p-4 text-xs text-ink-400">No saved jobs yet. Load or paste a posting, then save it here.</p> :
+      <ul className="mt-3 grid gap-2 md:grid-cols-2">{jobs.map((job) => <li key={job.id} className="flex min-w-0 items-center gap-2 rounded-lg border border-ink-700 px-3 py-2">
+        <button type="button" className="min-w-0 flex-1 text-left" onClick={() => onSelect(job)}><span className="block truncate text-sm text-paper">{job.title} <span className="text-brass-300">@ {job.company}</span></span><span className="block truncate font-mono text-[10px] text-ink-400">{job.source} · revision {job.revision} · {job.location || "location unspecified"}</span></button>
+        <button type="button" className="text-xs text-ink-400 hover:text-bad" aria-label={`Delete ${job.title} snapshot`} onClick={() => setJobs(deleteJobSnapshot(job.id))}>✕</button>
+      </li>)}</ul>}
+  </section>;
+}

--- a/lib/job-inbox.test.ts
+++ b/lib/job-inbox.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { addJobSnapshot, canonicalJobUrl, createJobSnapshot, duplicateKeys, parseJobImport } from "./job-inbox";
+
+const description = "Build reliable distributed systems with TypeScript, PostgreSQL, observability, testing, incident response, mentoring, collaboration, and production ownership across engineering teams.";
+const input = { company: "Acme", title: "Platform Engineer", location: "Remote", description, applicationUrl: "https://jobs.example.com/42?utm_source=x" };
+
+describe("job inbox", () => {
+  it("canonicalizes tracking URLs", () => expect(canonicalJobUrl(input.applicationUrl)).toBe("https://jobs.example.com/42"));
+  it("creates immutable revisions with SHA-256 content hashes", async () => {
+    const first = await createJobSnapshot(input, [], new Date("2026-01-01T00:00:00Z"));
+    const second = await createJobSnapshot({ ...input, description: `${description} New revision.` }, [first], new Date("2026-01-02T00:00:00Z"));
+    expect(first.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(second.revision).toBe(2);
+    expect(second.previousSnapshotId).toBe(first.id);
+    expect(first.description).toBe(description);
+  });
+  it("covers all four deduplication keys", async () => {
+    const first = await createJobSnapshot({ ...input, source: "lever", sourceId: "abc" });
+    const same = { ...first, id: crypto.randomUUID() };
+    expect(duplicateKeys(first, same).sort()).toEqual(["canonicalUrl", "companyTitleLocation", "descriptionHash", "sourceId"].sort());
+    expect(addJobSnapshot([first], same)).toMatchObject({ added: false, duplicateOf: first.id });
+  });
+  it("imports quoted CSV and JSON arrays", () => {
+    const csv = `company,title,location,description,url\n"Acme, Inc",Engineer,Remote,"${description}",https://example.com/job`;
+    expect(parseJobImport(csv, "csv")[0]).toMatchObject({ company: "Acme, Inc", source: "csv" });
+    expect(parseJobImport(JSON.stringify([{ company: "Beta", jobTitle: "Lead", description }]), "json")[0]).toMatchObject({ company: "Beta", title: "Lead", source: "json" });
+  });
+});

--- a/lib/job-inbox.ts
+++ b/lib/job-inbox.ts
@@ -1,0 +1,143 @@
+import {
+  JobPostingSnapshotSchema,
+  type JobPostingSnapshot,
+  type JobSource,
+  type RemoteStatus,
+} from "./schema";
+
+export interface JobImportInput {
+  source?: JobSource;
+  sourceId?: string;
+  company: string;
+  title: string;
+  location?: string;
+  remoteStatus?: RemoteStatus;
+  description: string;
+  requiredQualifications?: string[];
+  preferredQualifications?: string[];
+  applicationUrl?: string;
+  postedAt?: string | null;
+  closesAt?: string | null;
+}
+
+export type DuplicateKey = "sourceId" | "canonicalUrl" | "companyTitleLocation" | "descriptionHash";
+
+const normalize = (value: string) => value.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+
+export function canonicalJobUrl(value: string): string {
+  if (!value.trim()) return "";
+  const url = new URL(value.trim());
+  url.hash = "";
+  for (const key of [...url.searchParams.keys()]) {
+    if (/^(utm_|ref$|source$|trk$|tracking)/i.test(key)) url.searchParams.delete(key);
+  }
+  url.hostname = url.hostname.toLowerCase();
+  url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+  url.searchParams.sort();
+  return url.toString();
+}
+
+export async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value.normalize("NFKC").replace(/\r\n/g, "\n").trim());
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function createJobSnapshot(
+  input: JobImportInput,
+  existing: readonly JobPostingSnapshot[] = [],
+  now = new Date(),
+): Promise<JobPostingSnapshot> {
+  const description = input.description.trim();
+  const contentHash = await sha256(description);
+  const source = input.source ?? "manual";
+  const logicalMatches = existing.filter((job) =>
+    (input.sourceId && job.source === source && normalize(job.sourceId) === normalize(input.sourceId)) ||
+    (input.applicationUrl && canonicalJobUrl(job.applicationUrl) === canonicalJobUrl(input.applicationUrl)),
+  );
+  const latest = logicalMatches.sort((a, b) => b.revision - a.revision)[0];
+  const snapshot = {
+    id: crypto.randomUUID(),
+    source,
+    sourceId: input.sourceId?.trim() ?? "",
+    company: input.company.trim(),
+    title: input.title.trim(),
+    location: input.location?.trim() ?? "",
+    remoteStatus: input.remoteStatus ?? "unspecified",
+    compensation: null,
+    description,
+    requiredQualifications: input.requiredQualifications ?? [],
+    preferredQualifications: input.preferredQualifications ?? [],
+    applicationUrl: input.applicationUrl ? canonicalJobUrl(input.applicationUrl) : "",
+    postedAt: input.postedAt ?? null,
+    closesAt: input.closesAt ?? null,
+    contentHash,
+    importedAt: now.toISOString(),
+    revision: latest ? latest.revision + 1 : 1,
+    previousSnapshotId: latest?.id ?? null,
+  };
+  return JobPostingSnapshotSchema.parse(snapshot);
+}
+
+export function duplicateKeys(a: JobPostingSnapshot, b: JobPostingSnapshot): DuplicateKey[] {
+  const matches: DuplicateKey[] = [];
+  if (a.sourceId && b.sourceId && a.source === b.source && normalize(a.sourceId) === normalize(b.sourceId)) matches.push("sourceId");
+  if (a.applicationUrl && b.applicationUrl && canonicalJobUrl(a.applicationUrl) === canonicalJobUrl(b.applicationUrl)) matches.push("canonicalUrl");
+  if ([a.company, a.title, a.location].map(normalize).join("|") === [b.company, b.title, b.location].map(normalize).join("|")) matches.push("companyTitleLocation");
+  if (a.contentHash === b.contentHash) matches.push("descriptionHash");
+  return matches;
+}
+
+export function addJobSnapshot(
+  jobs: readonly JobPostingSnapshot[],
+  candidate: JobPostingSnapshot,
+): { jobs: JobPostingSnapshot[]; added: boolean; duplicateOf?: string } {
+  const identical = jobs.find((job) => job.contentHash === candidate.contentHash && duplicateKeys(job, candidate).length > 0);
+  if (identical) return { jobs: [...jobs], added: false, duplicateOf: identical.id };
+  return { jobs: [candidate, ...jobs], added: true };
+}
+
+function parseCsv(text: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [], field = "", quoted = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === '"' && quoted && text[i + 1] === '"') { field += '"'; i += 1; }
+    else if (char === '"') quoted = !quoted;
+    else if (char === "," && !quoted) { row.push(field); field = ""; }
+    else if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && text[i + 1] === "\n") i += 1;
+      row.push(field); if (row.some((cell) => cell.trim())) rows.push(row); row = []; field = "";
+    } else field += char;
+  }
+  row.push(field); if (row.some((cell) => cell.trim())) rows.push(row);
+  if (rows.length < 2) return [];
+  const headers = rows[0].map((header) => normalize(header));
+  return rows.slice(1).map((values) => Object.fromEntries(headers.map((header, index) => [header, values[index]?.trim() ?? ""])));
+}
+
+function recordToInput(record: Record<string, unknown>, source: JobSource): JobImportInput {
+  const get = (...keys: string[]) => keys.map((key) => record[key]).find((value) => typeof value === "string") as string | undefined;
+  return {
+    source,
+    sourceId: get("sourceid", "source_id", "id"),
+    company: get("company", "organization") ?? "Unknown company",
+    title: get("title", "jobtitle", "job_title") ?? "Untitled role",
+    location: get("location") ?? "",
+    description: get("description", "jobdescription", "job_description", "text") ?? "",
+    applicationUrl: get("applicationurl", "application_url", "url") ?? "",
+  };
+}
+
+export function parseJobImport(text: string, format: "csv" | "json"): JobImportInput[] {
+  if (format === "json") {
+    const parsed: unknown = JSON.parse(text);
+    const values = Array.isArray(parsed) ? parsed : [parsed];
+    return values.map((value) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Every JSON job must be an object.");
+      const normalized = Object.fromEntries(Object.entries(value).map(([key, entry]) => [normalize(key).replace(/\s+/g, "_"), entry]));
+      return recordToInput(normalized, "json");
+    });
+  }
+  return parseCsv(text).map((record) => recordToInput(record, "csv"));
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -148,3 +148,42 @@ export const TailorRequestSchema = z.object({
 });
 
 export type TailorRequest = z.infer<typeof TailorRequestSchema>;
+
+// ---- Job Search OS: normalized posting snapshots -----------------------
+export const JobSourceSchema = z.enum([
+  "manual", "url", "csv", "json", "greenhouse", "lever", "usajobs", "email", "other",
+]);
+export const RemoteStatusSchema = z.enum(["remote", "hybrid", "onsite", "unspecified"]);
+export const CompensationSchema = z.strictObject({
+  currency: z.string().min(3).max(3).default("USD"),
+  minimum: z.number().finite().nonnegative().nullable().default(null),
+  maximum: z.number().finite().nonnegative().nullable().default(null),
+  interval: z.enum(["hour", "day", "week", "month", "year", "other"]).default("year"),
+  description: z.string().max(500).default(""),
+}).refine((value) => value.maximum === null || value.minimum === null || value.maximum >= value.minimum,
+  "Compensation maximum must be greater than or equal to minimum.");
+
+export const JobPostingSnapshotSchema = z.strictObject({
+  id: z.string().min(1),
+  source: JobSourceSchema,
+  sourceId: z.string().max(500).default(""),
+  company: z.string().min(1).max(200),
+  title: z.string().min(1).max(200),
+  location: z.string().max(300).default(""),
+  remoteStatus: RemoteStatusSchema.default("unspecified"),
+  compensation: CompensationSchema.nullable().default(null),
+  description: z.string().min(100),
+  requiredQualifications: z.array(z.string().min(1).max(1000)).default([]),
+  preferredQualifications: z.array(z.string().min(1).max(1000)).default([]),
+  applicationUrl: z.string().url().or(z.literal("")),
+  postedAt: z.string().datetime().nullable().default(null),
+  closesAt: z.string().datetime().nullable().default(null),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  importedAt: z.string().datetime(),
+  revision: z.number().int().positive(),
+  previousSnapshotId: z.string().nullable().default(null),
+});
+
+export type JobSource = z.infer<typeof JobSourceSchema>;
+export type RemoteStatus = z.infer<typeof RemoteStatusSchema>;
+export type JobPostingSnapshot = z.infer<typeof JobPostingSnapshotSchema>;

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addSavePoint,
   clearAllData,
   deleteSavePoint,
+  loadJobInbox,
   loadSavePoints,
+  saveJobInbox,
   type Session,
 } from "./storage";
+import { createJobSnapshot } from "./job-inbox";
 
 class MemoryStorage {
   #values = new Map<string, string>();
@@ -23,6 +26,8 @@ const session: Session = {
   privacyMode: "protect",
   result: null,
 };
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("local save points", () => {
   beforeEach(() => {
@@ -59,5 +64,23 @@ describe("local save points", () => {
     addSavePoint({ resume: "private", extraInfo: "" }, session);
     clearAllData();
     expect(loadSavePoints()).toEqual([]);
+  });
+});
+
+describe("job inbox persistence", () => {
+  beforeEach(() => {
+    const localStorage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage });
+    vi.stubGlobal("localStorage", localStorage);
+  });
+
+  it("round-trips validated immutable snapshots", async () => {
+    const snapshot = await createJobSnapshot({
+      company: "Acme",
+      title: "Engineer",
+      description: "Build reliable software systems with testing, observability, security, collaboration, documentation, deployment, and customer-focused engineering practices.",
+    });
+    saveJobInbox([snapshot]);
+    expect(loadJobInbox()).toEqual([snapshot]);
   });
 });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,5 +1,6 @@
 import type { TailorResult } from "./schema";
 import type { PrivacyMode } from "./pii";
+import { JobPostingSnapshotSchema, type JobPostingSnapshot } from "./schema";
 
 /**
  * Local-first persistence. The profile and history live only in this
@@ -91,6 +92,7 @@ export interface SavePoint {
 const SESSION_KEY = "art:session";
 const SAVE_POINTS_KEY = "art:save-points";
 const SAVE_POINTS_LIMIT = 12;
+const JOB_INBOX_KEY = "art:job-inbox:v1";
 
 export function loadSession(): Partial<Session> | null {
   if (!canStore()) return null;
@@ -146,10 +148,35 @@ export function deleteSavePoint(id: string): SavePoint[] {
   return next;
 }
 
+export function loadJobInbox(): JobPostingSnapshot[] {
+  if (!canStore()) return [];
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(JOB_INBOX_KEY) ?? "[]");
+    return JobPostingSnapshotSchema.array().parse(parsed);
+  } catch {
+    return [];
+  }
+}
+
+/** Snapshots are append-only: callers can add a revision, never mutate one in place. */
+export function saveJobInbox(jobs: readonly JobPostingSnapshot[]): void {
+  if (!canStore()) return;
+  JobPostingSnapshotSchema.array().parse(jobs);
+  localStorage.setItem(JOB_INBOX_KEY, JSON.stringify(jobs));
+}
+
+export function deleteJobSnapshot(id: string): JobPostingSnapshot[] {
+  const next = loadJobInbox().filter((job) => job.id !== id);
+  saveJobInbox(next);
+  return next;
+}
+
 export function clearAllData(): void {
   if (!canStore()) return;
   localStorage.removeItem(PROFILE_KEY);
   localStorage.removeItem(HISTORY_KEY);
   localStorage.removeItem(SESSION_KEY);
   localStorage.removeItem(SAVE_POINTS_KEY);
+  localStorage.removeItem(JOB_INBOX_KEY);
+  window.dispatchEvent?.(new Event("resume-foundry:data-cleared"));
 }


### PR DESCRIPTION
Closes #12

## What changed
- defines the normalized `JobPostingSnapshot` schema in `lib/schema.ts`
- adds SHA-256 content hashing, canonical URLs, four-key duplicate detection, and append-only revision links
- imports URL/manual jobs plus quoted CSV and JSON arrays
- persists validated immutable snapshots in localStorage and erases them with the rest of local data
- adds an accessible Job Inbox UI for saving, importing, selecting, and deleting snapshots

## Validation
- `npm test` — 59/59
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- dedup test proves source ID, canonical URL, company/title/location, and description hash coverage
