### PR TITLE
Build auditable requirement evidence workspace

### DIFF
--- a/components/EvidenceWorkspace.tsx
+++ b/components/EvidenceWorkspace.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import type { TailorResult } from "@/lib/schema";
+
+const LABELS: Record<string, string> = {
+  proven: "Proven",
+  partially_supported: "Partially supported",
+  unsupported: "Unsupported",
+  needs_clarification: "Needs clarification",
+  intentionally_omitted: "Intentionally omitted",
+};
+
+export function EvidenceWorkspace({ items }: { items: TailorResult["requirement_evidence"] }) {
+  const [selected, setSelected] = useState(items[0]?.id ?? "");
+  if (items.length === 0) return null;
+  const active = items.find((item) => item.id === selected) ?? items[0];
+  const panel = "rounded-xl border border-ink-700 bg-ink-900/70 p-4";
+  return <section aria-labelledby="evidence-workspace-heading">
+    <div className="mb-3">
+      <h3 id="evidence-workspace-heading" className="text-xs font-semibold uppercase tracking-wider text-ink-300">Requirement → evidence → tailored text</h3>
+      <p className="mt-1 text-[11px] text-ink-400">Select a requirement to inspect exactly why the documents say what they say.</p>
+    </div>
+    <div className="grid gap-3 lg:grid-cols-3">
+      <div className={panel} aria-label="Job requirements">
+        <h4 className="mb-2 text-xs font-semibold text-brass-300">Job requirement</h4>
+        <div className="space-y-2">{items.map((item) => <button key={item.id} type="button" aria-pressed={item.id === active.id} onClick={() => setSelected(item.id)} className={`w-full rounded-lg border p-2 text-left text-xs ${item.id === active.id ? "border-brass-400 bg-brass-400/10" : "border-ink-700 hover:border-ink-500"}`}>
+          <span className="block text-ink-100">{item.requirement}</span>
+          <span className="mt-1 block font-mono text-[10px] text-ink-400">{item.category} · {LABELS[item.state]}</span>
+        </button>)}</div>
+      </div>
+      <div className={panel} aria-label="Resume evidence">
+        <h4 className="mb-2 text-xs font-semibold text-brass-300">Your evidence</h4>
+        {active.evidence.length ? <ul className="space-y-2 text-xs text-ink-100">{active.evidence.map((entry, index) => <li key={index} className="rounded-lg bg-ink-950 p-2">{entry}</li>)}</ul> : <p className="text-xs text-bad">No supporting résumé evidence.</p>}
+        {active.recommendation && <p className="mt-3 text-xs leading-relaxed text-warn">Next step: {active.recommendation}</p>}
+      </div>
+      <div className={panel} aria-label="Tailored application text">
+        <h4 className="mb-2 text-xs font-semibold text-brass-300">Tailored application</h4>
+        {active.tailoredText.length ? <ul className="space-y-2 text-xs text-ink-100">{active.tailoredText.map((entry, index) => <li key={index} className="rounded-lg bg-ink-950 p-2">{entry}</li>)}</ul> : <p className="text-xs text-ink-400">Nothing was added for this requirement.</p>}
+      </div>
+    </div>
+  </section>;
+}

--- a/components/ResultView.tsx
+++ b/components/ResultView.tsx
@@ -6,6 +6,7 @@ import { mdToAtsText, mdToHtml } from "@/lib/markdown";
 import { downloadDocx } from "@/lib/docx-export";
 import { Chip, CopyButton, ScoreDial, ToolButton, downloadText } from "./ui";
 import { ReadAloudControls } from "./SpeechControls";
+import { EvidenceWorkspace } from "./EvidenceWorkspace";
 
 const KIND_LABEL: Record<TailorResult["changes"][number]["kind"], string> = {
   reworded: "Reworded",
@@ -54,6 +55,8 @@ export function ResultView({
           {result.score_rationale}
         </p>
       </div>
+
+      <EvidenceWorkspace items={result.requirement_evidence ?? []} />
 
       {/* Keywords */}
       <div className="grid gap-4 md:grid-cols-3">

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -30,6 +30,8 @@ You know how 2026 ATS actually work, and you optimize for reality, not myth:
 
 Scoring: match_score_before and match_score_after measure how a competent recruiter + ATS would rank the resume against THIS posting's stated requirements (skills coverage, title/seniority alignment, domain fit, quantified evidence). Be calibrated, not flattering: most honest tailoring moves a score 10-25 points, and match_score_after stays below 90 when real requirement gaps remain. Explain the arithmetic of your scoring in score_rationale.
 
+For requirement_evidence, enumerate every material mandatory requirement, preferred qualification, responsibility, and logistical constraint. Link each supported item to exact facts from the original resume and exact text in the tailored documents. If unsupported, evidence and tailoredText MUST both be empty; use recommendation for an honest clarification question, adjacent skill, portfolio task, training/certification, or intentional omission. Never turn a recommendation into a claimed qualification.
+
 The cover letter must be specific to this candidate and this posting — reference at least two concrete items from the resume and at least one from the posting. No generic filler.`;
 
 export function buildUserPrompt(req: TailorRequest): string {

--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -16,6 +16,15 @@ const VALID_RESULT = {
     not_added: [{ keyword: "rust", reason: "no evidence in resume" }],
   },
   gap_analysis: [{ gap: "No Rust experience", advice: "Ship a small Rust CLI project" }],
+  requirement_evidence: [{
+    id: "rust",
+    requirement: "Rust",
+    category: "mandatory",
+    state: "unsupported",
+    evidence: [] as string[],
+    tailoredText: [] as string[],
+    recommendation: "Build and publish a small Rust project.",
+  }],
   ats_checks: [{ check: "Single column", status: "pass", note: "OK" }],
   tailored_resume_markdown: "# Jane Doe",
   cover_letter_markdown: "Dear [Hiring Manager]…",
@@ -37,6 +46,15 @@ describe("TailorResultSchema", () => {
         changes: [{ kind: "fabricated", detail: "x" }],
       }),
     ).toThrow();
+  });
+
+  it("rejects unsupported requirements that claim evidence or tailored text", () => {
+    const dishonest = structuredClone(VALID_RESULT);
+    dishonest.requirement_evidence[0] = {
+      ...dishonest.requirement_evidence[0],
+      evidence: ["Invented Rust experience"],
+    };
+    expect(() => TailorResultSchema.parse(dishonest)).toThrow(/Unsupported requirements/);
   });
 });
 

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,5 +1,26 @@
 import { z } from "zod";
 
+export const EvidenceStateSchema = z.enum([
+  "proven", "partially_supported", "unsupported", "needs_clarification", "intentionally_omitted",
+]);
+
+export const RequirementEvidenceSchema = z.strictObject({
+  id: z.string().min(1).max(100),
+  requirement: z.string().min(1),
+  category: z.enum(["mandatory", "preferred", "responsibility", "logistics"]),
+  state: EvidenceStateSchema,
+  evidence: z.array(z.string()).describe("Exact facts from the original resume supporting this requirement; empty when unsupported"),
+  tailoredText: z.array(z.string()).describe("Exact resulting resume or cover-letter text tied to this requirement; empty when unsupported"),
+  recommendation: z.string().describe("Honest next step, clarification, adjacent skill, portfolio task, training, or omission rationale"),
+}).superRefine((item, context) => {
+  if (item.state === "unsupported" && (item.evidence.length > 0 || item.tailoredText.length > 0)) {
+    context.addIssue({ code: "custom", message: "Unsupported requirements cannot claim evidence or tailored text." });
+  }
+  if ((item.state === "proven" || item.state === "partially_supported") && item.evidence.length === 0) {
+    context.addIssue({ code: "custom", message: "Supported requirements must cite résumé evidence." });
+  }
+});
+
 export const TailorResultSchema = z.strictObject({
   match_score_before: z
     .int()
@@ -60,6 +81,9 @@ export const TailorResultSchema = z.strictObject({
       }),
     )
     .describe("Honest gaps the candidate should know about"),
+  requirement_evidence: z
+    .array(RequirementEvidenceSchema)
+    .describe("Auditable mapping of each material job requirement to source résumé evidence and resulting tailored text"),
   ats_checks: z
     .array(
       z.strictObject({


### PR DESCRIPTION
Closes #13

## What changed
- adds a typed requirement/evidence contract covering mandatory, preferred, responsibility, and logistics requirements
- renders synchronized requirement, original-résumé evidence, and tailored-text panels with linked selection
- enforces the five evidence states in the schema and prompt
- rejects unsupported requirements that claim evidence or resulting tailored text
- requires proven/partially-supported requirements to cite source résumé evidence

## Validation
- `npm test` — 60/60
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- regression test proves structurally dishonest unsupported claims fail server-side validation
