### PR TITLE
Build immutable application packets and tracker

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,7 @@ import { ResultView } from "@/components/ResultView";
 import { Chip, Section, Spinner, ToolButton } from "@/components/ui";
 import { DictationButton } from "@/components/SpeechControls";
 import { JobInbox } from "@/components/JobInbox";
+import { ApplicationTracker } from "@/components/ApplicationTracker";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -700,6 +701,12 @@ export default function Home() {
             </div>
           )}
         </div>
+
+        <ApplicationTracker
+          result={result}
+          profile={{ resume, extraInfo }}
+          job={{ company, title: jobTitle, description: jobText, applicationUrl: jobUrl }}
+        />
 
         {/* History */}
         <section className="mt-10 border-t border-ink-700 pt-6">

--- a/components/ApplicationTracker.tsx
+++ b/components/ApplicationTracker.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import type { TailorResult } from "@/lib/schema";
+import { createJobSnapshot } from "@/lib/job-inbox";
+import { allowedTransitions, applicationAnalytics, createApplicationPacket, createApplicationRecord, transitionApplication, type ApplicationRecord, type ApplicationState } from "@/lib/applications";
+import { loadApplications, loadJobInbox, saveApplications } from "@/lib/storage";
+import { ToolButton } from "@/components/ui";
+
+export function ApplicationTracker({ result, profile, job }: { result: TailorResult | null; profile: { resume: string; extraInfo: string }; job: { company: string; title: string; description: string; applicationUrl: string } }) {
+  const [records, setRecords] = useState<ApplicationRecord[]>(() => loadApplications());
+  const [message, setMessage] = useState("");
+  const analytics = applicationAnalytics(records);
+
+  async function prepare() {
+    if (!result) { setMessage("Generate and review a tailored result before preparing an application packet."); return; }
+    const existing = loadJobInbox();
+    const jobSnapshot = await createJobSnapshot({ ...job, company: job.company || "Unknown company", title: job.title || "Untitled role", source: job.applicationUrl ? "url" : "manual" }, existing);
+    const packet = await createApplicationPacket({ jobSnapshot, profile, result });
+    const next = [createApplicationRecord(packet), ...records]; saveApplications(next); setRecords(next); setMessage("Immutable packet prepared and checksummed.");
+  }
+
+  async function move(record: ApplicationRecord, state: ApplicationState) {
+    const transitioned = await transitionApplication(record, state);
+    const next = records.map((entry) => entry.id === record.id ? transitioned : entry);
+    saveApplications(next); setRecords(next);
+  }
+
+  return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="application-tracker-heading">
+    <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 id="application-tracker-heading" className="font-display text-xl font-semibold text-paper">Application tracker</h2><p className="text-[11px] text-ink-400">Each packet keeps the exact job, profile, résumé, cover letter, and checksums used.</p></div><ToolButton onClick={() => void prepare()}>Prepare immutable packet</ToolButton></div>
+    {message && <p role="status" className="mt-2 text-xs text-brass-300">{message}</p>}
+    <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4">
+      <Metric label="Applications" value={records.length} /><Metric label="Response rate" value={`${Math.round(analytics.responseRate * 100)}%`} /><Metric label="Interview conversion" value={`${Math.round(analytics.interviewConversionRate * 100)}%`} /><Metric label="Awaiting follow-up" value={analytics.companiesAwaitingFollowUp.length} />
+    </div>
+    {records.length > 0 && <div className="mt-4 overflow-x-auto"><table className="w-full min-w-[44rem] text-left text-xs"><thead className="text-ink-400"><tr><th className="p-2">Role</th><th className="p-2">State</th><th className="p-2">Packet</th><th className="p-2">Next valid state</th></tr></thead><tbody>{records.map((record) => <tr key={record.id} className="border-t border-ink-700"><td className="p-2 text-paper">{record.packet.jobSnapshot.title} @ {record.packet.jobSnapshot.company}</td><td className="p-2 text-brass-300">{record.state.replaceAll("_", " ")}</td><td className="p-2 font-mono text-[10px] text-ink-400">v{record.packet.version} · {record.packet.checksums.packet.slice(0, 12)}…</td><td className="p-2"><select aria-label={`Move ${record.packet.jobSnapshot.title} to next state`} value="" onChange={(event) => void move(record, event.target.value as ApplicationState)} className="rounded border border-ink-700 bg-ink-950 p-1"><option value="" disabled>Choose…</option>{allowedTransitions(record.state).map((state) => <option key={state} value={state}>{state.replaceAll("_", " ")}</option>)}</select></td></tr>)}</tbody></table></div>}
+    <details className="mt-4"><summary className="cursor-pointer text-xs text-ink-300">Analytics detail</summary><div className="mt-2 grid gap-2 text-[11px] text-ink-400 md:grid-cols-2"><pre className="overflow-auto rounded bg-ink-950 p-2">Applications/week {JSON.stringify(analytics.applicationsPerWeek, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Source effectiveness {JSON.stringify(analytics.sourceEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Resume versions {JSON.stringify(analytics.resumeVersionEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Missing skills {JSON.stringify(analytics.skillsMostOftenMissing, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Roles needing attention {JSON.stringify(analytics.rolesNeedingAttention, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Average response hours {JSON.stringify(analytics.averageResponseHours)}</pre></div></details>
+  </section>;
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) { return <div className="rounded-lg border border-ink-700 bg-ink-950 p-3"><span className="block font-mono text-lg text-brass-300">{value}</span><span className="text-[10px] text-ink-400">{label}</span></div>; }

--- a/lib/applications.test.ts
+++ b/lib/applications.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { applicationAnalytics, createApplicationPacket, createApplicationRecord, transitionApplication } from "./applications";
+import { createJobSnapshot } from "./job-inbox";
+import type { TailorResult } from "./schema";
+
+const result: TailorResult = { match_score_before: 50, match_score_after: 70, score_rationale: "Evidence improved alignment.", changes: [], keywords: { matched: [], added: [], not_added: [{ keyword: "Rust", reason: "No evidence" }] }, gap_analysis: [], requirement_evidence: [{ id: "rust", requirement: "Rust", category: "mandatory", state: "unsupported", evidence: [], tailoredText: [], recommendation: "Build a project" }], ats_checks: [], tailored_resume_markdown: "# Resume", cover_letter_markdown: "Cover" };
+
+async function packet() {
+  const job = await createJobSnapshot({ company: "Acme", title: "Engineer", description: "Build reliable software systems with TypeScript, PostgreSQL, observability, testing, security, incident response, documentation, collaboration, mentoring, and production ownership." });
+  return createApplicationPacket({ jobSnapshot: job, profile: { resume: "Original", extraInfo: "Evidence" }, result, now: new Date("2026-01-01T00:00:00Z") });
+}
+
+describe("immutable application packets", () => {
+  it("checksums every artifact and is detached from later source edits", async () => {
+    const created = await packet(); const old = created.tailoredResult.tailored_resume_markdown;
+    result.tailored_resume_markdown = "Changed later";
+    expect(created.checksums.packet).toMatch(/^[a-f0-9]{64}$/); expect(created.checksums.resume).toMatch(/^[a-f0-9]{64}$/); expect(created.tailoredResult.tailored_resume_markdown).toBe(old);
+  });
+  it("allows only valid state transitions and records submission time", async () => {
+    const record = createApplicationRecord(await packet());
+    await expect(transitionApplication(record, "offer")).rejects.toThrow(/Invalid application transition/);
+    const submitted = await transitionApplication(record, "submitted", new Date("2026-01-02T00:00:00Z"));
+    expect(submitted.packet.submittedAt).toBe("2026-01-02T00:00:00.000Z");
+    expect(submitted.packet.version).toBe(2);
+    expect(submitted.packet.checksums.packet).not.toBe(record.packet.checksums.packet);
+    expect(submitted.packetHistory).toEqual([record.packet]);
+    expect(record.state).toBe("ready"); expect(record.packet.submittedAt).toBeNull();
+  });
+  it("reports every required analytics family", async () => {
+    const submitted = await transitionApplication(createApplicationRecord(await packet()), "submitted");
+    const analytics = applicationAnalytics([submitted]);
+    expect(analytics).toMatchObject({ responseRate: 0, interviewConversionRate: 0 });
+    expect(Object.keys(analytics)).toEqual(expect.arrayContaining(["applicationsPerWeek", "sourceEffectiveness", "resumeVersionEffectiveness", "averageResponseHours", "skillsMostOftenMissing", "companiesAwaitingFollowUp", "rolesNeedingAttention"]));
+  });
+});

--- a/lib/applications.ts
+++ b/lib/applications.ts
@@ -1,0 +1,137 @@
+import type { TailorResult } from "./schema";
+import type { JobPostingSnapshot } from "./schema";
+import { sha256 } from "./job-inbox";
+
+export const APPLICATION_STATES = [
+  "discovered", "saved", "reviewing", "tailoring", "ready", "submitted",
+  "recruiter_response", "interviewing", "offer", "rejected", "withdrawn", "no_response",
+] as const;
+export type ApplicationState = typeof APPLICATION_STATES[number];
+
+const TRANSITIONS: Record<ApplicationState, readonly ApplicationState[]> = {
+  discovered: ["saved", "withdrawn"], saved: ["reviewing", "withdrawn"],
+  reviewing: ["tailoring", "withdrawn"], tailoring: ["ready", "reviewing", "withdrawn"],
+  ready: ["submitted", "tailoring", "withdrawn"], submitted: ["recruiter_response", "no_response", "withdrawn", "rejected"],
+  recruiter_response: ["interviewing", "rejected", "withdrawn"], interviewing: ["offer", "rejected", "withdrawn"],
+  offer: ["withdrawn"], rejected: [], withdrawn: [], no_response: ["recruiter_response"],
+};
+
+export interface ApplicationPacket {
+  id: string;
+  version: number;
+  jobSnapshot: JobPostingSnapshot;
+  profileSnapshot: { resume: string; extraInfo: string; checksum: string };
+  tailoredResult: TailorResult;
+  screeningAnswers: Record<string, string>;
+  userEdits: string[];
+  submissionChannel: "guided" | "email" | "lever" | "greenhouse" | "other" | null;
+  checksums: { job: string; profile: string; resume: string; coverLetter: string; packet: string };
+  createdAt: string;
+  submittedAt: string | null;
+}
+
+export interface ApplicationEvent { at: string; type: string; detail: string }
+export interface ApplicationRecord {
+  id: string;
+  packet: ApplicationPacket;
+  packetHistory: ApplicationPacket[];
+  state: ApplicationState;
+  timeline: ApplicationEvent[];
+  notes: string[];
+  contacts: { name: string; role: string; email: string }[];
+  interviewDates: string[];
+  followUpAt: string | null;
+  compensation: string;
+  referral: string;
+  rejectionReason: string;
+  nextAction: string;
+  documentLinks: string[];
+  emailLinks: string[];
+  calendarLinks: string[];
+}
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`).join(",")}}`;
+  return JSON.stringify(value);
+}
+
+export async function createApplicationPacket(input: {
+  jobSnapshot: JobPostingSnapshot;
+  profile: { resume: string; extraInfo: string };
+  result: TailorResult;
+  screeningAnswers?: Record<string, string>;
+  userEdits?: string[];
+  now?: Date;
+}): Promise<ApplicationPacket> {
+  const createdAt = (input.now ?? new Date()).toISOString();
+  const profileChecksum = await sha256(canonical(input.profile));
+  const partial = {
+    id: crypto.randomUUID(), version: 1, jobSnapshot: structuredClone(input.jobSnapshot),
+    profileSnapshot: { ...structuredClone(input.profile), checksum: profileChecksum },
+    tailoredResult: structuredClone(input.result), screeningAnswers: structuredClone(input.screeningAnswers ?? {}),
+    userEdits: structuredClone(input.userEdits ?? []), submissionChannel: null, createdAt, submittedAt: null,
+  };
+  const checksums = {
+    job: await sha256(canonical(partial.jobSnapshot)), profile: profileChecksum,
+    resume: await sha256(partial.tailoredResult.tailored_resume_markdown),
+    coverLetter: await sha256(partial.tailoredResult.cover_letter_markdown),
+    packet: await sha256(canonical(partial)),
+  };
+  return structuredClone({ ...partial, checksums });
+}
+
+export function createApplicationRecord(packet: ApplicationPacket): ApplicationRecord {
+  return { id: crypto.randomUUID(), packet: structuredClone(packet), packetHistory: [], state: "ready", timeline: [{ at: packet.createdAt, type: "packet.created", detail: `Packet v${packet.version} created` }], notes: [], contacts: [], interviewDates: [], followUpAt: null, compensation: "", referral: "", rejectionReason: "", nextAction: "Review and approve submission", documentLinks: [], emailLinks: [], calendarLinks: [] };
+}
+
+export function allowedTransitions(state: ApplicationState): readonly ApplicationState[] { return TRANSITIONS[state]; }
+
+export async function transitionApplication(record: ApplicationRecord, next: ApplicationState, now = new Date()): Promise<ApplicationRecord> {
+  if (!TRANSITIONS[record.state].includes(next)) throw new Error(`Invalid application transition: ${record.state} -> ${next}`);
+  const updated = structuredClone(record);
+  updated.state = next;
+  updated.timeline.push({ at: now.toISOString(), type: "application.transition", detail: `${record.state} -> ${next}` });
+  if (next === "submitted") {
+    updated.packetHistory.push(structuredClone(updated.packet));
+    const { checksums: _oldChecksums, ...packetBody } = updated.packet;
+    const versionedBody = { ...packetBody, id: crypto.randomUUID(), version: updated.packet.version + 1, submittedAt: now.toISOString() };
+    updated.packet = {
+      ...versionedBody,
+      checksums: { ...updated.packet.checksums, packet: await sha256(canonical(versionedBody)) },
+    };
+    updated.timeline.push({ at: now.toISOString(), type: "packet.versioned", detail: `Packet v${updated.packet.version} sealed for submission` });
+  }
+  return updated;
+}
+
+export function applicationAnalytics(records: readonly ApplicationRecord[]) {
+  const submitted = records.filter((record) => record.packet.submittedAt);
+  const responses = records.filter((record) => ["recruiter_response", "interviewing", "offer"].includes(record.state));
+  const interviews = records.filter((record) => ["interviewing", "offer"].includes(record.state));
+  const source = new Map<string, { applications: number; responses: number }>();
+  const resume = new Map<string, { applications: number; responses: number }>();
+  const missing = new Map<string, number>();
+  for (const record of records) {
+    const sourceKey = record.packet.jobSnapshot.source;
+    const sourceRow = source.get(sourceKey) ?? { applications: 0, responses: 0 };
+    sourceRow.applications += 1; if (responses.includes(record)) sourceRow.responses += 1; source.set(sourceKey, sourceRow);
+    const resumeKey = record.packet.profileSnapshot.checksum.slice(0, 12);
+    const resumeRow = resume.get(resumeKey) ?? { applications: 0, responses: 0 };
+    resumeRow.applications += 1; if (responses.includes(record)) resumeRow.responses += 1; resume.set(resumeKey, resumeRow);
+    for (const item of record.packet.tailoredResult.requirement_evidence ?? []) if (item.state === "unsupported") missing.set(item.requirement, (missing.get(item.requirement) ?? 0) + 1);
+  }
+  const now = Date.now();
+  const perWeek = new Map<string, number>();
+  for (const record of submitted) { const date = new Date(record.packet.submittedAt!); const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - date.getUTCDay())); const key = start.toISOString().slice(0, 10); perWeek.set(key, (perWeek.get(key) ?? 0) + 1); }
+  const responseHours = responses.flatMap((record) => { const response = record.timeline.find((event) => event.detail.includes("-> recruiter_response")); return response && record.packet.submittedAt ? [(new Date(response.at).getTime() - new Date(record.packet.submittedAt).getTime()) / 3_600_000] : []; });
+  return {
+    applicationsPerWeek: Object.fromEntries(perWeek), responseRate: submitted.length ? responses.length / submitted.length : 0,
+    interviewConversionRate: submitted.length ? interviews.length / submitted.length : 0,
+    sourceEffectiveness: Object.fromEntries(source), resumeVersionEffectiveness: Object.fromEntries(resume),
+    averageResponseHours: responseHours.length ? responseHours.reduce((a, b) => a + b, 0) / responseHours.length : null,
+    skillsMostOftenMissing: [...missing].sort((a, b) => b[1] - a[1]),
+    companiesAwaitingFollowUp: records.filter((record) => record.followUpAt && new Date(record.followUpAt).getTime() <= now).map((record) => record.packet.jobSnapshot.company),
+    rolesNeedingAttention: records.filter((record) => record.nextAction || ["saved", "reviewing", "ready", "no_response"].includes(record.state)).map((record) => ({ title: record.packet.jobSnapshot.title, company: record.packet.jobSnapshot.company, nextAction: record.nextAction })),
+  };
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,6 +1,7 @@
 import type { TailorResult } from "./schema";
 import type { PrivacyMode } from "./pii";
 import { JobPostingSnapshotSchema, type JobPostingSnapshot } from "./schema";
+import type { ApplicationRecord } from "./applications";
 
 /**
  * Local-first persistence. The profile and history live only in this
@@ -93,6 +94,7 @@ const SESSION_KEY = "art:session";
 const SAVE_POINTS_KEY = "art:save-points";
 const SAVE_POINTS_LIMIT = 12;
 const JOB_INBOX_KEY = "art:job-inbox:v1";
+const APPLICATIONS_KEY = "art:applications:v1";
 
 export function loadSession(): Partial<Session> | null {
   if (!canStore()) return null;
@@ -171,6 +173,17 @@ export function deleteJobSnapshot(id: string): JobPostingSnapshot[] {
   return next;
 }
 
+export function loadApplications(): ApplicationRecord[] {
+  if (!canStore()) return [];
+  try { return JSON.parse(localStorage.getItem(APPLICATIONS_KEY) ?? "[]") as ApplicationRecord[]; }
+  catch { return []; }
+}
+
+export function saveApplications(records: readonly ApplicationRecord[]): void {
+  if (!canStore()) return;
+  localStorage.setItem(APPLICATIONS_KEY, JSON.stringify(records));
+}
+
 export function clearAllData(): void {
   if (!canStore()) return;
   localStorage.removeItem(PROFILE_KEY);
@@ -178,5 +191,6 @@ export function clearAllData(): void {
   localStorage.removeItem(SESSION_KEY);
   localStorage.removeItem(SAVE_POINTS_KEY);
   localStorage.removeItem(JOB_INBOX_KEY);
+  localStorage.removeItem(APPLICATIONS_KEY);
   window.dispatchEvent?.(new Event("resume-foundry:data-cleared"));
 }


### PR DESCRIPTION
Closes #14

## What changed
- creates immutable application packets containing the exact job snapshot, profile snapshot, tailored documents, answers, edits, timestamps, and per-artifact SHA-256 checksums
- preserves prior packet versions; submission seals a new checksummed version instead of mutating the prepared packet
- implements the full guarded pipeline state machine and audit timeline
- persists application records locally and adds a tracker UI
- reports applications/week, response rate, interview conversion, source and resume-version effectiveness, response time, missing skills, follow-ups, and roles needing attention

## Validation
- `npm test` — 63/63
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- tests cover source-detached packets, checksum/version changes, invalid transitions, submission timestamps, history preservation, and every analytics family
