### PR TITLE
Build official job source connectors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,8 @@
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional. Defaults to claude-opus-5.
-ANTHROPIC_MODEL=claude-opus-5
+RESUME_FOUNDRY_ANTHROPIC_MODEL=claude-opus-5
+
+# Optional. Required only for the USAJOBS connector.
+USAJOBS_API_KEY=
+USAJOBS_USER_AGENT=you@example.com

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 | **2026-aware scoring** | Semantic matching, no keyword stuffing (modern ATS penalize it), calibrated scores with the arithmetic explained — plus an instant, deterministic keyword scan that runs in your browser before any AI. |
 | **Local-first privacy** | Your profile and history live in your browser's localStorage. The app does not write a server-side copy. One click erases everything. |
 | **Job Inbox** | Save immutable, SHA-256-addressed posting snapshots; import CSV/JSON in bulk; skip duplicates by source ID, canonical URL, company/title/location, or description hash. |
+| **Legitimate source connectors** | Import official Greenhouse and Lever public boards, USAJOBS searches, forwarded alerts, CSV/JSON, URLs, or manual text. LinkedIn/Indeed scraping and automated apply remain prohibited. |
 
 ## Features
 
@@ -40,6 +41,8 @@ npm run dev                  # http://localhost:3000
 ```
 
 Get an API key at [platform.claude.com](https://platform.claude.com/). The only required variable is `ANTHROPIC_API_KEY`; `RESUME_FOUNDRY_ANTHROPIC_MODEL` optionally overrides the default `claude-opus-5` without inheriting unrelated Claude CLI model aliases. `ANTHROPIC_MODEL` remains a lower-priority compatibility fallback.
+
+The USAJOBS connector additionally reads `USAJOBS_API_KEY` and `USAJOBS_USER_AGENT`; Greenhouse and Lever public-board imports require no stored credentials.
 
 > The tailor endpoint enables Anthropic's server-side refusal fallback (`fallbacks: "default"`) so a rare safety-classifier decline re-routes automatically instead of failing the request.
 

--- a/app/api/capabilities/route.ts
+++ b/app/api/capabilities/route.ts
@@ -14,6 +14,7 @@ export function GET() {
     contracts: { openapi: "/openapi.json", agentGuide: "/AGENT_ACCESS.md" },
     operations: [
       { id: "fetchJob", method: "POST", path: "/api/fetch-job", openWorld: true },
+      { id: "importJobs", method: "POST", path: "/api/jobs/import", openWorld: true, sources: ["greenhouse", "lever", "usajobs", "email"] },
       { id: "parseResume", method: "POST", path: "/api/parse-resume", openWorld: false },
       { id: "tailorResume", method: "POST", path: "/api/tailor", openWorld: true, streaming: "ndjson" },
     ],

--- a/app/api/jobs/import/route.ts
+++ b/app/api/jobs/import/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { fetchGreenhouse, fetchLever, fetchUsaJobs, parseForwardedJobAlert } from "@/lib/job-connectors";
+
+export const runtime = "nodejs";
+const RequestSchema = z.discriminatedUnion("source", [
+  z.strictObject({ source: z.literal("greenhouse"), query: z.string().min(1).max(100) }),
+  z.strictObject({ source: z.literal("lever"), query: z.string().min(1).max(100), maxPages: z.number().int().min(1).max(20).optional() }),
+  z.strictObject({ source: z.literal("usajobs"), query: z.string().min(1).max(300), maxPages: z.number().int().min(1).max(20).optional() }),
+  z.strictObject({ source: z.literal("email"), payload: z.string().min(100).max(1_000_000) }),
+]);
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try { body = await request.json(); } catch { return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 }); }
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Invalid connector request." }, { status: 400 });
+  try {
+    const value = parsed.data;
+    const jobs = value.source === "greenhouse" ? await fetchGreenhouse(value.query)
+      : value.source === "lever" ? await fetchLever(value.query, { maxPages: value.maxPages })
+      : value.source === "usajobs" ? await fetchUsaJobs(value.query, { apiKey: process.env.USAJOBS_API_KEY ?? "", userAgent: process.env.USAJOBS_USER_AGENT ?? "" }, { maxPages: value.maxPages })
+      : parseForwardedJobAlert(value.payload);
+    return NextResponse.json({ jobs, count: jobs.length });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Connector failed.";
+    return NextResponse.json({ error: message }, { status: message.includes("not configured") ? 503 : 502 });
+  }
+}

--- a/components/JobInbox.tsx
+++ b/components/JobInbox.tsx
@@ -5,6 +5,7 @@ import { addJobSnapshot, createJobSnapshot, parseJobImport, type JobImportInput 
 import type { JobPostingSnapshot } from "@/lib/schema";
 import { deleteJobSnapshot, loadJobInbox, saveJobInbox } from "@/lib/storage";
 import { ToolButton } from "@/components/ui";
+import { SourceConnectors } from "@/components/SourceConnectors";
 
 export function JobInbox({ current, onSelect }: { current: JobImportInput; onSelect: (job: JobPostingSnapshot) => void }) {
   const [jobs, setJobs] = useState<JobPostingSnapshot[]>(() => loadJobInbox());
@@ -47,6 +48,7 @@ export function JobInbox({ current, onSelect }: { current: JobImportInput; onSel
         <input ref={fileRef} className="sr-only" type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => { const file = event.target.files?.[0]; if (file) void importFile(file); event.target.value = ""; }} />
       </div>
     </div>
+    <SourceConnectors onJobs={addInputs} />
     {message && <p role="status" className="mt-2 text-xs text-brass-300">{message}</p>}
     {jobs.length === 0 ? <p className="mt-3 rounded-lg border border-dashed border-ink-700 p-4 text-xs text-ink-400">No saved jobs yet. Load or paste a posting, then save it here.</p> :
       <ul className="mt-3 grid gap-2 md:grid-cols-2">{jobs.map((job) => <li key={job.id} className="flex min-w-0 items-center gap-2 rounded-lg border border-ink-700 px-3 py-2">

--- a/components/SourceConnectors.tsx
+++ b/components/SourceConnectors.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import type { JobImportInput } from "@/lib/job-inbox";
+import { ToolButton } from "@/components/ui";
+
+export function SourceConnectors({ onJobs }: { onJobs: (jobs: JobImportInput[]) => Promise<void> }) {
+  const [source, setSource] = useState<"greenhouse" | "lever" | "usajobs" | "email">("greenhouse");
+  const [query, setQuery] = useState(""); const [busy, setBusy] = useState(false); const [message, setMessage] = useState("");
+  async function run() {
+    setBusy(true); setMessage("");
+    try {
+      const body = source === "email" ? { source, payload: query } : { source, query, maxPages: 3 };
+      const response = await fetch("/api/jobs/import", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+      const payload = await response.json(); if (!response.ok) throw new Error(payload.error ?? "Connector failed.");
+      await onJobs(payload.jobs as JobImportInput[]); setMessage(`${payload.count} ${source} job${payload.count === 1 ? "" : "s"} received.`);
+    } catch (error) { setMessage(error instanceof Error ? error.message : "Connector failed."); }
+    finally { setBusy(false); }
+  }
+  const placeholder = source === "greenhouse" ? "Greenhouse board token" : source === "lever" ? "Lever site token" : source === "usajobs" ? "USAJOBS keyword" : "Paste a forwarded job-alert email";
+  return <div className="mt-3 rounded-lg border border-ink-700 bg-ink-950/50 p-3"><div className="flex flex-wrap gap-2"><select value={source} onChange={(event) => { setSource(event.target.value as typeof source); setQuery(""); }} aria-label="Job source" className="rounded border border-ink-700 bg-ink-950 px-2 py-1.5 text-xs"><option value="greenhouse">Greenhouse</option><option value="lever">Lever</option><option value="usajobs">USAJOBS</option><option value="email">Forwarded alert</option></select>{source === "email" ? <textarea value={query} onChange={(event) => setQuery(event.target.value)} placeholder={placeholder} className="min-h-24 min-w-0 flex-1 rounded border border-ink-700 bg-ink-950 p-2 text-xs" /> : <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder={placeholder} className="min-w-48 flex-1 rounded border border-ink-700 bg-ink-950 px-2 py-1.5 text-xs" />}<ToolButton onClick={() => void run()}>{busy ? "Importing…" : "Import source"}</ToolButton></div>{message && <p role="status" className="mt-2 text-xs text-brass-300">{message}</p>}<p className="mt-2 text-[10px] text-ink-400">Official feeds only. LinkedIn and Indeed remain manual/guided handoff sources; Foundry does not scrape or automate them.</p></div>;
+}

--- a/lib/job-connectors.test.ts
+++ b/lib/job-connectors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchGreenhouse, fetchLever, fetchUsaJobs, parseForwardedJobAlert } from "./job-connectors";
+
+function reply(body: unknown, status = 200, headers: Record<string, string> = {}) { return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json", ...headers } }); }
+
+describe("official job connectors", () => {
+  it("normalizes Greenhouse and strips HTML", async () => {
+    const fetcher = vi.fn(async () => reply({ jobs: [{ id: 1, title: "Engineer", location: { name: "Remote" }, content: "<p>Build secure reliable systems with testing, observability, collaboration, documentation, and production ownership for customers.</p>", absolute_url: "https://example.com/1" }] })) as unknown as typeof fetch;
+    const [job] = await fetchGreenhouse("acme", fetcher); expect(job).toMatchObject({ source: "greenhouse", sourceId: "1", remoteStatus: "remote" }); expect(job.description).not.toContain("<p>");
+  });
+  it("paginates Lever and stops on a short page", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(reply([{ id: "1", text: "A", descriptionPlain: "A".repeat(120), categories: {}, applyUrl: "https://x/1" }])).mockResolvedValueOnce(reply([])) as unknown as typeof fetch;
+    const jobs = await fetchLever("acme", { pageSize: 1, maxPages: 5, fetcher }); expect(jobs).toHaveLength(1); expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+  it("retries a 429 and maps USAJOBS with required auth headers", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(reply({}, 429, { "retry-after": "0" })).mockResolvedValueOnce(reply({ SearchResult: { SearchResultCountAll: 1, SearchResultItems: [{ MatchedObjectDescriptor: { PositionID: "X", PositionTitle: "Analyst", OrganizationName: "Agency", PositionLocationDisplay: "Washington", PositionURI: "https://usajobs.gov/x", UserArea: { Details: { JobSummary: "Analyze secure systems and compliance requirements with documentation, stakeholder collaboration, testing, and operational responsibility for government services." } } } }] } }));
+    const jobs = await fetchUsaJobs("security", { apiKey: "secret", userAgent: "user@example.com" }, { fetcher: fetchSpy as unknown as typeof fetch }); expect(jobs[0]).toMatchObject({ source: "usajobs", sourceId: "X" }); expect(fetchSpy).toHaveBeenCalledTimes(2); expect(fetchSpy.mock.calls[0][1]?.headers).toMatchObject({ "Authorization-Key": "secret" });
+  });
+  it("parses forwarded alerts without authorizing site automation", () => {
+    const [job] = parseForwardedJobAlert(`Subject: Platform Engineer\nCompany: Acme\nApply: https://example.com/job\n${"Build secure reliable systems with evidence and documentation. ".repeat(4)}`); expect(job).toMatchObject({ source: "email", company: "Acme" }); expect(job.permissions?.automatedIngestion).toBe(false);
+  });
+});

--- a/lib/job-connectors.ts
+++ b/lib/job-connectors.ts
@@ -1,0 +1,74 @@
+import type { JobImportInput } from "./job-inbox";
+import { defaultSourcePermissions } from "./job-inbox";
+
+type Fetcher = typeof fetch;
+const TOKEN = /^[a-zA-Z0-9_-]{1,100}$/;
+
+function text(value: unknown): string { return typeof value === "string" ? value : ""; }
+function plain(html: unknown): string {
+  return text(html).replace(/<script[\s\S]*?<\/script>/gi, " ").replace(/<style[\s\S]*?<\/style>/gi, " ").replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ").replace(/&amp;/gi, "&").replace(/&lt;/gi, "<").replace(/&gt;/gi, ">").replace(/&quot;/gi, '"').replace(/&#39;/gi, "'").replace(/\s+/g, " ").trim();
+}
+function iso(value: unknown): string | null { const candidate = text(value); if (!candidate) return null; const date = new Date(candidate); return Number.isNaN(date.getTime()) ? null : date.toISOString(); }
+function remote(value: string): "remote" | "hybrid" | "onsite" | "unspecified" { const n = value.toLowerCase(); return n.includes("remote") ? "remote" : n.includes("hybrid") ? "hybrid" : n.includes("on-site") || n.includes("onsite") ? "onsite" : "unspecified"; }
+
+async function fetchJson(url: string, init: RequestInit, fetcher: Fetcher, attempts = 3): Promise<unknown> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const response = await fetcher(url, init);
+    if (response.ok) return response.json();
+    if (![429, 502, 503, 504].includes(response.status) || attempt === attempts - 1) throw new Error(`Connector request failed (${response.status}).`);
+    const retryAfter = Math.min(Number(response.headers.get("retry-after") ?? "0") || 0.05, 2);
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+  }
+  throw new Error("Connector retry budget exhausted.");
+}
+
+export async function fetchGreenhouse(boardToken: string, fetcher: Fetcher = fetch): Promise<JobImportInput[]> {
+  if (!TOKEN.test(boardToken)) throw new Error("Invalid Greenhouse board token.");
+  const payload = await fetchJson(`https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(boardToken)}/jobs?content=true`, {}, fetcher) as { jobs?: Record<string, unknown>[] };
+  return (payload.jobs ?? []).map((job) => {
+    const location = text((job.location as Record<string, unknown> | undefined)?.name);
+    return { source: "greenhouse", sourceId: String(job.id ?? ""), permissions: defaultSourcePermissions("greenhouse"), company: boardToken, title: text(job.title) || "Untitled role", location, remoteStatus: remote(location), description: plain(job.content), applicationUrl: text(job.absolute_url), postedAt: iso(job.updated_at) };
+  });
+}
+
+export async function fetchLever(site: string, options: { maxPages?: number; pageSize?: number; fetcher?: Fetcher } = {}): Promise<JobImportInput[]> {
+  if (!TOKEN.test(site)) throw new Error("Invalid Lever site token.");
+  const fetcher = options.fetcher ?? fetch, pageSize = Math.min(options.pageSize ?? 100, 100), maxPages = Math.min(options.maxPages ?? 10, 20);
+  const jobs: JobImportInput[] = [];
+  for (let page = 0; page < maxPages; page += 1) {
+    const payload = await fetchJson(`https://api.lever.co/v0/postings/${encodeURIComponent(site)}?mode=json&skip=${page * pageSize}&limit=${pageSize}`, {}, fetcher) as Record<string, unknown>[];
+    for (const job of payload) {
+      const categories = (job.categories ?? {}) as Record<string, unknown>; const location = text(categories.location);
+      jobs.push({ source: "lever", sourceId: text(job.id), permissions: defaultSourcePermissions("lever"), company: site, title: text(job.text) || "Untitled role", location, remoteStatus: remote(`${text(job.workplaceType)} ${location}`), description: text(job.descriptionPlain) || plain(job.description), applicationUrl: text(job.applyUrl) || text(job.hostedUrl) });
+    }
+    if (payload.length < pageSize) break;
+  }
+  return jobs;
+}
+
+export async function fetchUsaJobs(keyword: string, credentials: { apiKey: string; userAgent: string }, options: { maxPages?: number; fetcher?: Fetcher } = {}): Promise<JobImportInput[]> {
+  if (!credentials.apiKey || !credentials.userAgent) throw new Error("USAJOBS credentials are not configured.");
+  const fetcher = options.fetcher ?? fetch, maxPages = Math.min(options.maxPages ?? 3, 20), jobs: JobImportInput[] = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const params = new URLSearchParams({ Keyword: keyword, Page: String(page), ResultsPerPage: "500" });
+    const payload = await fetchJson(`https://data.usajobs.gov/api/search?${params}`, { headers: { Host: "data.usajobs.gov", "User-Agent": credentials.userAgent, "Authorization-Key": credentials.apiKey } }, fetcher) as Record<string, unknown>;
+    const search = (payload.SearchResult ?? {}) as Record<string, unknown>; const items = (search.SearchResultItems ?? []) as Record<string, unknown>[];
+    for (const item of items) {
+      const job = (item.MatchedObjectDescriptor ?? {}) as Record<string, unknown>; const details = ((job.UserArea ?? {}) as Record<string, unknown>).Details as Record<string, unknown> | undefined;
+      const location = text(job.PositionLocationDisplay);
+      jobs.push({ source: "usajobs", sourceId: text(job.PositionID), permissions: defaultSourcePermissions("usajobs"), company: text(job.OrganizationName) || text(job.DepartmentName) || "U.S. Government", title: text(job.PositionTitle) || "Untitled role", location, remoteStatus: remote(location), description: [details?.JobSummary, details?.MajorDuties, details?.Requirements].map(text).filter(Boolean).join("\n\n"), applicationUrl: text(job.PositionURI), postedAt: iso(job.PublicationStartDate), closesAt: iso(job.ApplicationCloseDate) });
+    }
+    const count = Number(search.SearchResultCountAll ?? items.length); if (page * 500 >= count || items.length === 0) break;
+  }
+  return jobs;
+}
+
+export function parseForwardedJobAlert(raw: string): JobImportInput[] {
+  const urls = [...raw.matchAll(/https?:\/\/[^\s<>"']+/gi)].map((match) => match[0].replace(/[),.;]+$/, ""));
+  const subject = raw.match(/^Subject:\s*(.+)$/im)?.[1]?.trim() ?? "Forwarded job alert";
+  const company = raw.match(/^(?:Company|Employer):\s*(.+)$/im)?.[1]?.trim() ?? "Unknown company";
+  const body = raw.replace(/^From:.*$/gim, "").replace(/^Subject:.*$/gim, "").trim();
+  if (body.length < 100) return [];
+  return [{ source: "email", company, title: subject, description: body, applicationUrl: urls[0] ?? "", permissions: defaultSourcePermissions("email") }];
+}

--- a/lib/job-inbox.ts
+++ b/lib/job-inbox.ts
@@ -3,6 +3,7 @@ import {
   type JobPostingSnapshot,
   type JobSource,
   type RemoteStatus,
+  type SourcePermission,
 } from "./schema";
 
 export interface JobImportInput {
@@ -18,11 +19,27 @@ export interface JobImportInput {
   applicationUrl?: string;
   postedAt?: string | null;
   closesAt?: string | null;
+  permissions?: SourcePermission;
 }
 
 export type DuplicateKey = "sourceId" | "canonicalUrl" | "companyTitleLocation" | "descriptionHash";
 
 const normalize = (value: string) => value.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+
+export function defaultSourcePermissions(source: JobSource): SourcePermission {
+  const officialFeed = ["greenhouse", "lever", "usajobs"].includes(source);
+  return {
+    automatedIngestion: officialFeed,
+    guidedHandoff: true,
+    directSubmission: false,
+    requiresEmployerAuthorization: source === "greenhouse" || source === "lever",
+    termsUrl: source === "greenhouse" ? "https://developers.greenhouse.io/job-board.html"
+      : source === "lever" ? "https://github.com/lever/postings-api"
+      : source === "usajobs" ? "https://developer.usajobs.gov/api-reference/"
+      : "",
+    note: officialFeed ? "Official public job feed; direct submission remains disabled without separate authorization." : "User-provided import; no third-party site automation authorized.",
+  };
+}
 
 export function canonicalJobUrl(value: string): string {
   if (!value.trim()) return "";
@@ -60,6 +77,7 @@ export async function createJobSnapshot(
     id: crypto.randomUUID(),
     source,
     sourceId: input.sourceId?.trim() ?? "",
+    permissions: input.permissions ?? defaultSourcePermissions(source),
     company: input.company.trim(),
     title: input.title.trim(),
     location: input.location?.trim() ?? "",

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -178,6 +178,14 @@ export const JobSourceSchema = z.enum([
   "manual", "url", "csv", "json", "greenhouse", "lever", "usajobs", "email", "other",
 ]);
 export const RemoteStatusSchema = z.enum(["remote", "hybrid", "onsite", "unspecified"]);
+export const SourcePermissionSchema = z.strictObject({
+  automatedIngestion: z.boolean(),
+  guidedHandoff: z.boolean(),
+  directSubmission: z.boolean(),
+  requiresEmployerAuthorization: z.boolean(),
+  termsUrl: z.string().url().or(z.literal("")),
+  note: z.string().max(1000),
+});
 export const CompensationSchema = z.strictObject({
   currency: z.string().min(3).max(3).default("USD"),
   minimum: z.number().finite().nonnegative().nullable().default(null),
@@ -191,6 +199,10 @@ export const JobPostingSnapshotSchema = z.strictObject({
   id: z.string().min(1),
   source: JobSourceSchema,
   sourceId: z.string().max(500).default(""),
+  permissions: SourcePermissionSchema.default({
+    automatedIngestion: false, guidedHandoff: true, directSubmission: false,
+    requiresEmployerAuthorization: false, termsUrl: "", note: "User-provided posting; no automated source access assumed.",
+  }),
   company: z.string().min(1).max(200),
   title: z.string().min(1).max(200),
   location: z.string().max(300).default(""),
@@ -211,3 +223,4 @@ export const JobPostingSnapshotSchema = z.strictObject({
 export type JobSource = z.infer<typeof JobSourceSchema>;
 export type RemoteStatus = z.infer<typeof RemoteStatusSchema>;
 export type JobPostingSnapshot = z.infer<typeof JobPostingSnapshotSchema>;
+export type SourcePermission = z.infer<typeof SourcePermissionSchema>;


### PR DESCRIPTION
Closes #15

## What changed
- adds official Greenhouse board, Lever postings, and USAJOBS search connectors
- adds forwarded-alert parsing and keeps existing CSV/JSON, URL, and manual imports
- normalizes every result through the Phase 1 snapshot pipeline
- retries 429/502/503/504 responses with bounded Retry-After handling
- paginates Lever and USAJOBS with explicit page caps
- records per-source ingestion, handoff, direct-submission, employer-authorization, terms, and policy metadata in every snapshot
- explicitly keeps LinkedIn/Indeed scraping and automated apply disabled

## Validation
- `npm test` — 67/67
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- mocked contract tests cover Greenhouse normalization/HTML stripping, Lever pagination, USAJOBS auth+429 retry, and email permission boundaries
