### PR TITLE
Build consent-gated guided application handoff

### DIFF
--- a/components/ApplicationTracker.tsx
+++ b/components/ApplicationTracker.tsx
@@ -6,10 +6,12 @@ import { createJobSnapshot } from "@/lib/job-inbox";
 import { allowedTransitions, applicationAnalytics, createApplicationPacket, createApplicationRecord, transitionApplication, type ApplicationRecord, type ApplicationState } from "@/lib/applications";
 import { loadApplications, loadJobInbox, saveApplications } from "@/lib/storage";
 import { ToolButton } from "@/components/ui";
+import { GuidedHandoff } from "@/components/GuidedHandoff";
 
 export function ApplicationTracker({ result, profile, job }: { result: TailorResult | null; profile: { resume: string; extraInfo: string }; job: { company: string; title: string; description: string; applicationUrl: string } }) {
   const [records, setRecords] = useState<ApplicationRecord[]>(() => loadApplications());
   const [message, setMessage] = useState("");
+  const [handoff, setHandoff] = useState<ApplicationRecord | null>(null);
   const analytics = applicationAnalytics(records);
 
   async function prepare() {
@@ -33,7 +35,9 @@ export function ApplicationTracker({ result, profile, job }: { result: TailorRes
       <Metric label="Applications" value={records.length} /><Metric label="Response rate" value={`${Math.round(analytics.responseRate * 100)}%`} /><Metric label="Interview conversion" value={`${Math.round(analytics.interviewConversionRate * 100)}%`} /><Metric label="Awaiting follow-up" value={analytics.companiesAwaitingFollowUp.length} />
     </div>
     {records.length > 0 && <div className="mt-4 overflow-x-auto"><table className="w-full min-w-[44rem] text-left text-xs"><thead className="text-ink-400"><tr><th className="p-2">Role</th><th className="p-2">State</th><th className="p-2">Packet</th><th className="p-2">Next valid state</th></tr></thead><tbody>{records.map((record) => <tr key={record.id} className="border-t border-ink-700"><td className="p-2 text-paper">{record.packet.jobSnapshot.title} @ {record.packet.jobSnapshot.company}</td><td className="p-2 text-brass-300">{record.state.replaceAll("_", " ")}</td><td className="p-2 font-mono text-[10px] text-ink-400">v{record.packet.version} · {record.packet.checksums.packet.slice(0, 12)}…</td><td className="p-2"><select aria-label={`Move ${record.packet.jobSnapshot.title} to next state`} value="" onChange={(event) => void move(record, event.target.value as ApplicationState)} className="rounded border border-ink-700 bg-ink-950 p-1"><option value="" disabled>Choose…</option>{allowedTransitions(record.state).map((state) => <option key={state} value={state}>{state.replaceAll("_", " ")}</option>)}</select></td></tr>)}</tbody></table></div>}
+    {records.length > 0 && <div className="mt-3 flex flex-wrap gap-2">{records.map((record) => <ToolButton key={record.id} onClick={() => setHandoff(record)}>Guided handoff: {record.packet.jobSnapshot.title}</ToolButton>)}</div>}
     <details className="mt-4"><summary className="cursor-pointer text-xs text-ink-300">Analytics detail</summary><div className="mt-2 grid gap-2 text-[11px] text-ink-400 md:grid-cols-2"><pre className="overflow-auto rounded bg-ink-950 p-2">Applications/week {JSON.stringify(analytics.applicationsPerWeek, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Source effectiveness {JSON.stringify(analytics.sourceEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Resume versions {JSON.stringify(analytics.resumeVersionEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Missing skills {JSON.stringify(analytics.skillsMostOftenMissing, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Roles needing attention {JSON.stringify(analytics.rolesNeedingAttention, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Average response hours {JSON.stringify(analytics.averageResponseHours)}</pre></div></details>
+    {handoff && <GuidedHandoff record={handoff} onClose={() => setHandoff(null)} />}
   </section>;
 }
 

--- a/components/GuidedHandoff.tsx
+++ b/components/GuidedHandoff.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ApplicationRecord } from "@/lib/applications";
+import { buildHandoffReview, validHandoffDestination } from "@/lib/handoff";
+import { CopyButton, ToolButton } from "@/components/ui";
+
+export function GuidedHandoff({ record, onClose }: { record: ApplicationRecord; onClose: () => void }) {
+  const review = useMemo(() => buildHandoffReview(record), [record]);
+  const [consents, setConsents] = useState<Set<string>>(new Set());
+  const ready = review.requiredConsents.every((consent) => consents.has(consent)) && validHandoffDestination(review.destination);
+  const toggle = (value: string) => setConsents((current) => { const next = new Set(current); if (next.has(value)) next.delete(value); else next.add(value); return next; });
+  return <div role="dialog" aria-modal="true" aria-labelledby="handoff-title" className="fixed inset-0 z-50 overflow-y-auto bg-ink-950/90 p-4"><div className="mx-auto max-w-3xl rounded-xl border border-brass-400/40 bg-ink-900 p-5 shadow-2xl">
+    <h2 id="handoff-title" className="font-display text-2xl text-paper">Final guided-handoff review</h2><p className="mt-1 text-xs text-ink-400">Foundry will open the official page. It will not fill, manipulate, or submit the site.</p>
+    <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2"><Field label="Company" value={review.company} /><Field label="Role" value={review.role} /><Field label="Destination" value={review.destination || "Missing"} /><Field label="Submission method" value="Manual guided handoff" /><Field label="Packet version" value={`v${review.packetVersion}`} /><Field label="Résumé version" value={review.resumeVersion} /><Field label="Cover-letter version" value={review.coverLetterVersion} /><Field label="Personal data disclosed" value={review.personalDataCategories.join(", ") || "No standard contact identifiers detected"} /></dl>
+    <div className="mt-4 grid gap-3 md:grid-cols-2"><Document title="Tailored résumé" text={record.packet.tailoredResult.tailored_resume_markdown} /><Document title="Cover letter" text={record.packet.tailoredResult.cover_letter_markdown} /></div>
+    <div className="mt-4 rounded-lg border border-ink-700 p-3"><h3 className="text-xs font-semibold text-paper">Screening answers</h3>{Object.keys(review.answers).length ? Object.entries(review.answers).map(([question, answer]) => <div key={question} className="mt-2 flex items-start gap-2 text-xs"><div className="min-w-0 flex-1"><span className="block text-ink-400">{question}</span><span className="text-ink-100">{answer}</span></div><CopyButton text={answer} /></div>) : <p className="mt-1 text-xs text-ink-400">No screening answers stored in this packet.</p>}</div>
+    <div className="mt-4 space-y-2 text-xs"><Consent checked={consents.has("reviewed-packet")} onChange={() => toggle("reviewed-packet")} label="I reviewed the exact résumé, cover letter, and answers in this packet." /><Consent checked={consents.has("reviewed-personal-data")} onChange={() => toggle("reviewed-personal-data")} label="I reviewed the personal-data categories that may be disclosed." /><Consent checked={consents.has("understands-manual-handoff")} onChange={() => toggle("understands-manual-handoff")} label="I understand Foundry only opens the destination; I remain responsible for reviewing and submitting there." /></div>
+    {!review.destination && <p role="alert" className="mt-3 text-xs text-bad">This packet has no application URL. Add an official destination before handoff.</p>}
+    <div className="mt-5 flex flex-wrap justify-end gap-2"><ToolButton onClick={onClose}>Cancel</ToolButton><button type="button" disabled={!ready} onClick={() => window.open(review.destination, "_blank", "noopener,noreferrer")} className="rounded-lg border border-brass-400/50 bg-brass-400/10 px-4 py-2 text-xs font-semibold text-brass-300 disabled:opacity-40">Open official application page</button></div>
+  </div></div>;
+}
+
+function Field({ label, value }: { label: string; value: string }) { return <div className="rounded-lg bg-ink-950 p-2"><dt className="font-mono text-[10px] text-ink-400">{label}</dt><dd className="break-all text-ink-100">{value}</dd></div>; }
+function Document({ title, text }: { title: string; text: string }) { return <div className="rounded-lg border border-ink-700 p-3"><div className="flex items-center justify-between"><h3 className="text-xs font-semibold text-paper">{title}</h3><CopyButton text={text} /></div><pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-[10px] text-ink-300">{text}</pre></div>; }
+function Consent({ checked, onChange, label }: { checked: boolean; onChange: () => void; label: string }) { return <label className="flex items-start gap-2"><input type="checkbox" checked={checked} onChange={onChange} className="mt-0.5" /><span>{label}</span></label>; }

--- a/lib/handoff.test.ts
+++ b/lib/handoff.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildHandoffReview, validHandoffDestination } from "./handoff";
+import type { ApplicationRecord } from "./applications";
+
+const record = { packet: { version: 2, jobSnapshot: { company: "Acme", title: "Engineer", applicationUrl: "https://www.linkedin.com/jobs/view/123" }, profileSnapshot: { resume: "Jane Doe jane@example.com 555-555-1212", extraInfo: "" }, checksums: { resume: "a".repeat(64), coverLetter: "b".repeat(64) }, screeningAnswers: { sponsorship: "No" } } } as unknown as ApplicationRecord;
+
+describe("guided handoff", () => {
+  it("shows every required confirmation field and detected PII category", () => {
+    expect(buildHandoffReview(record)).toMatchObject({ company: "Acme", role: "Engineer", destination: "https://www.linkedin.com/jobs/view/123", packetVersion: 2, answers: { sponsorship: "No" }, submissionMethod: "guided-manual", personalDataCategories: expect.arrayContaining(["email", "phone"]) });
+  });
+  it("allows official HTTPS destinations without automating them", () => {
+    expect(validHandoffDestination("https://www.indeed.com/viewjob?jk=1")).toBe(true);
+    expect(validHandoffDestination("javascript:alert(1)")).toBe(false);
+    expect(validHandoffDestination("http://evil.example/job")).toBe(false);
+  });
+});

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -1,0 +1,31 @@
+import type { ApplicationRecord } from "./applications";
+import { protectPii } from "./pii";
+
+export interface HandoffReview {
+  company: string; role: string; destination: string; packetVersion: number;
+  resumeVersion: string; coverLetterVersion: string; answers: Record<string, string>;
+  personalDataCategories: string[]; submissionMethod: "guided-manual";
+  requiredConsents: string[];
+}
+
+export function buildHandoffReview(record: ApplicationRecord): HandoffReview {
+  const packet = record.packet;
+  const combined = `${packet.profileSnapshot.resume}\n${packet.profileSnapshot.extraInfo}`;
+  return {
+    company: packet.jobSnapshot.company,
+    role: packet.jobSnapshot.title,
+    destination: packet.jobSnapshot.applicationUrl,
+    packetVersion: packet.version,
+    resumeVersion: packet.checksums.resume.slice(0, 12),
+    coverLetterVersion: packet.checksums.coverLetter.slice(0, 12),
+    answers: structuredClone(packet.screeningAnswers),
+    personalDataCategories: [...new Set(protectPii(combined).matches.map((match) => match.kind))],
+    submissionMethod: "guided-manual",
+    requiredConsents: ["reviewed-packet", "reviewed-personal-data", "understands-manual-handoff"],
+  };
+}
+
+export function validHandoffDestination(value: string): boolean {
+  try { const url = new URL(value); return url.protocol === "https:" || (url.protocol === "http:" && ["localhost", "127.0.0.1"].includes(url.hostname)); }
+  catch { return false; }
+}


### PR DESCRIPTION
Closes #17

## What changed
- adds a final confirmation dialog showing company, role, destination, packet/resume/cover versions, screening answers, PII categories, and manual submission method
- requires three explicit consent acknowledgments before opening the official application page
- provides manual copy controls for exact packet documents and answers
- validates HTTPS destinations and rejects script/non-secure remote URLs
- opens LinkedIn/Indeed or other official pages without filling, manipulating, or submitting them

## Validation
- `npm test` — 69/69
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- tests cover required review fields, PII categories, LinkedIn/Indeed destinations, and unsafe URL rejection
