### PR TITLE
Add durable lifetime career evidence ledger

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ import { Chip, Section, Spinner, ToolButton } from "@/components/ui";
 import { DictationButton } from "@/components/SpeechControls";
 import { JobInbox } from "@/components/JobInbox";
 import { ApplicationTracker } from "@/components/ApplicationTracker";
+import { CareerLedger } from "@/components/CareerLedger";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -701,6 +702,8 @@ export default function Home() {
             </div>
           )}
         </div>
+
+        <CareerLedger />
 
         <ApplicationTracker
           result={result}

--- a/components/CareerLedger.tsx
+++ b/components/CareerLedger.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  appendCareerEvent, createCareerLedger, exportEncryptedCareerLedger, importEncryptedCareerLedger,
+  currentCareerEvents, type CareerLedger as Ledger,
+} from "@/lib/career-ledger";
+import { loadCareerLedger, saveCareerLedger } from "@/lib/career-vault";
+import { ToolButton } from "@/components/ui";
+
+export function CareerLedger() {
+  const [ledger, setLedger] = useState<Ledger | null>(null);
+  const [title, setTitle] = useState(""); const [description, setDescription] = useState("");
+  const [category, setCategory] = useState<"project" | "coursework" | "paid_work" | "volunteering" | "other">("project");
+  const [passphrase, setPassphrase] = useState(""); const [status, setStatus] = useState("Loading private career vault…");
+  useEffect(() => { void loadCareerLedger().then((saved) => { setLedger(saved); setStatus(saved ? "Career ledger restored from this browser." : "No ledger yet. Create one to start tracking."); }).catch((error: unknown) => setStatus(error instanceof Error ? error.message : "Vault unavailable.")); }, []);
+
+  async function ensureLedger() {
+    const next = ledger ?? createCareerLedger(crypto.randomUUID()); await saveCareerLedger(next); setLedger(next); setStatus("Private career ledger ready.");
+  }
+  async function add() {
+    if (!ledger || !title.trim() || !description.trim()) { setStatus("Create the ledger and enter a title and description first."); return; }
+    const next = await appendCareerEvent(ledger, {
+      occurredAt: new Date().toISOString(), category, title: title.trim(), description: description.trim(), originalSource: "",
+      claimState: "fact", verification: "self_reported", skills: [], measurableResult: "", collaborators: [], context: "",
+      confidence: 1, tags: [], occupationCodes: [], evidence: [], visibility: "private", supersedesEventId: null, correctionReason: "",
+    });
+    await saveCareerLedger(next); setLedger(next); setTitle(""); setDescription(""); setStatus("Entry appended. Earlier history was not rewritten.");
+  }
+  async function downloadBackup() {
+    if (!ledger) return; const backup = await exportEncryptedCareerLedger(ledger, passphrase);
+    const link = document.createElement("a"); link.href = URL.createObjectURL(new Blob([JSON.stringify(backup, null, 2)], { type: "application/json" }));
+    link.download = `resume-foundry-career-vault-${new Date().toISOString().slice(0, 10)}.json`; link.click(); URL.revokeObjectURL(link.href);
+    localStorage.setItem("rf:career-last-backup", new Date().toISOString()); setStatus("Encrypted recovery backup downloaded. Keep the passphrase separately.");
+  }
+  async function restore(file: File | undefined) {
+    if (!file) return;
+    try { const restored = await importEncryptedCareerLedger(JSON.parse(await file.text()), passphrase); await saveCareerLedger(restored); setLedger(restored); setStatus("Backup decrypted, integrity-checked, and restored."); }
+    catch (error) { setStatus(error instanceof Error ? error.message : "Restore failed."); }
+  }
+  const active = ledger ? currentCareerEvents(ledger) : [];
+  const lastBackup = typeof window === "undefined" ? null : localStorage.getItem("rf:career-last-backup");
+  return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="career-ledger-heading">
+    <div className="flex flex-wrap items-start justify-between gap-3"><div><h2 id="career-ledger-heading" className="font-display text-xl font-semibold text-paper">Career ledger</h2><p className="text-[11px] text-ink-400">Keep projects, work, learning, volunteering, caregiving, and evidence for future uses you cannot predict yet.</p></div>{!ledger && <ToolButton onClick={() => void ensureLedger()}>Create private ledger</ToolButton>}</div>
+    <p role="status" className="mt-2 text-xs text-brass-300">{status}</p>
+    {ledger && <>
+      <div className="mt-3 grid gap-2 md:grid-cols-[10rem_1fr_2fr_auto]"><select aria-label="Entry category" value={category} onChange={(event) => setCategory(event.target.value as typeof category)} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"><option value="project">Project</option><option value="coursework">Coursework</option><option value="paid_work">Paid work</option><option value="volunteering">Volunteering</option><option value="other">Other</option></select><input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="What happened?" maxLength={300} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"/><input value={description} onChange={(event) => setDescription(event.target.value)} placeholder="What did you do, learn, or accomplish?" maxLength={20000} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"/><ToolButton onClick={() => void add()}>Append entry</ToolButton></div>
+      <div className="mt-3 flex flex-wrap items-center gap-2"><input type="password" value={passphrase} onChange={(event) => setPassphrase(event.target.value)} placeholder="Backup passphrase (12+ characters)" aria-label="Career backup passphrase" className="min-w-64 rounded border border-ink-700 bg-ink-950 p-2 text-xs"/><ToolButton onClick={() => void downloadBackup()}>Download encrypted backup</ToolButton><label className="cursor-pointer rounded border border-ink-600 px-3 py-2 text-xs text-paper">Restore backup<input type="file" accept="application/json" className="sr-only" onChange={(event) => void restore(event.target.files?.[0])}/></label></div>
+      <p className="mt-2 text-[10px] text-ink-400">{lastBackup ? `Last backup: ${new Date(lastBackup).toLocaleString()}` : "No recovery backup recorded yet. Browser storage alone is not a decades-long backup."}</p>
+      <ol className="mt-3 space-y-2">{active.slice().reverse().map((entry) => <li key={entry.id} className="rounded border border-ink-700 bg-ink-950 p-3"><div className="flex flex-wrap justify-between gap-2"><strong className="text-sm text-paper">{entry.title}</strong><span className="font-mono text-[10px] text-ink-400">#{entry.sequence} · {entry.verification.replaceAll("_", " ")} · {entry.visibility}</span></div><p className="mt-1 text-xs text-ink-300">{entry.description}</p></li>)}</ol>
+      <p className="mt-3 text-[10px] text-ink-500">Every entry is hash-chained. Corrections become linked new events; AI suggestions remain unconfirmed until you approve them.</p>
+    </>}
+  </section>;
+}

--- a/lib/career-ledger.test.ts
+++ b/lib/career-ledger.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendCareerEvent, createCareerLedger, createDisclosurePacket, currentCareerEvents,
+  exportEncryptedCareerLedger, importEncryptedCareerLedger, verifyCareerLedger,
+  type CareerEventInput,
+} from "./career-ledger";
+
+const event = (overrides: Partial<CareerEventInput> = {}): CareerEventInput => ({
+  occurredAt: "2026-01-10T12:00:00.000Z", category: "project", title: "Robotics team",
+  description: "Built and tested the drivetrain with three classmates.", originalSource: "Workshop notebook page 14",
+  claimState: "fact", verification: "artifact_attached",
+  skills: [{ name: "hardware testing", state: "fact", source: "user" }],
+  measurableResult: "Robot completed the course.", collaborators: ["Team member"], context: "School club",
+  confidence: 0.95, tags: ["robotics"], occupationCodes: ["17-3024.00"],
+  evidence: [{ id: "notebook-14", kind: "file", label: "Notebook", digest: "a".repeat(64), locator: "vault://notebook" }],
+  visibility: "packet_selectable", supersedesEventId: null, correctionReason: "", ...overrides,
+});
+
+describe("career evidence ledger", () => {
+  it("appends immutable hash-chained events and detects mutation", async () => {
+    const original = createCareerLedger("owner-1", new Date("2026-01-01T00:00:00Z"));
+    const first = await appendCareerEvent(original, event(), new Date("2026-01-11T00:00:00Z"));
+    const second = await appendCareerEvent(first, event({ title: "Volunteer shift", category: "volunteering" }), new Date("2026-02-01T00:00:00Z"));
+    expect(original.events).toHaveLength(0);
+    expect(await verifyCareerLedger(second)).toEqual({ valid: true, errors: [] });
+    const tampered = structuredClone(second); tampered.events[0].description = "Invented replacement";
+    expect((await verifyCareerLedger(tampered)).valid).toBe(false);
+  });
+
+  it("corrects by superseding instead of rewriting history", async () => {
+    let ledger = await appendCareerEvent(createCareerLedger("owner-1"), event());
+    const original = ledger.events[0];
+    ledger = await appendCareerEvent(ledger, event({ title: "Robotics team — corrected", supersedesEventId: original.id, correctionReason: "Corrected the project title." }));
+    expect(ledger.events).toHaveLength(2);
+    expect(ledger.events[0].title).toBe("Robotics team");
+    expect(currentCareerEvents(ledger).map((entry) => entry.title)).toEqual(["Robotics team — corrected"]);
+    await expect(appendCareerEvent(ledger, event({ supersedesEventId: original.id }))).rejects.toThrow(/explain/);
+  });
+
+  it("keeps AI suggestions unconfirmed and distinct from facts", async () => {
+    const ledger = await appendCareerEvent(createCareerLedger("owner-1"), event({
+      claimState: "unconfirmed_inference",
+      skills: [{ name: "systems engineering", state: "unconfirmed_inference", source: "ai_suggestion" }],
+    }));
+    expect(ledger.events[0].claimState).toBe("unconfirmed_inference");
+    expect(ledger.events[0].skills[0].state).not.toBe("fact");
+  });
+
+  it("selectively discloses only eligible events and removes private source details", async () => {
+    let ledger = await appendCareerEvent(createCareerLedger("owner-1"), event());
+    ledger = await appendCareerEvent(ledger, event({ title: "Private reflection", visibility: "private" }));
+    const packet = await createDisclosurePacket(ledger, ledger.events.map((entry) => entry.id));
+    expect(packet.events).toHaveLength(1);
+    expect(packet.events[0].title).toBe("Robotics team");
+    expect(packet.events[0]).not.toHaveProperty("originalSource");
+    expect(packet.events[0]).not.toHaveProperty("collaborators");
+    expect(packet.checksum).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("exports and restores an encrypted, provider-independent backup losslessly", async () => {
+    const ledger = await appendCareerEvent(createCareerLedger("owner-1"), event());
+    const backup = await exportEncryptedCareerLedger(ledger, "a strong recovery phrase");
+    expect(JSON.stringify(backup)).not.toContain("Robotics team");
+    await expect(importEncryptedCareerLedger(backup, "wrong passphrase")).rejects.toThrow(/could not be decrypted/);
+    expect(await importEncryptedCareerLedger(backup, "a strong recovery phrase")).toEqual(ledger);
+  });
+
+  it("rejects tampered encrypted backup bytes", async () => {
+    const backup = await exportEncryptedCareerLedger(await appendCareerEvent(createCareerLedger("owner-1"), event()), "a strong recovery phrase");
+    const tampered = { ...backup, ciphertext: `${backup.ciphertext.slice(0, -2)}AA` };
+    await expect(importEncryptedCareerLedger(tampered, "a strong recovery phrase")).rejects.toThrow(/integrity verification/);
+  });
+});

--- a/lib/career-ledger.ts
+++ b/lib/career-ledger.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+
+export const CAREER_LEDGER_SCHEMA_VERSION = 1 as const;
+
+export const CareerEventCategorySchema = z.enum([
+  "project", "coursework", "paid_work", "volunteering", "caregiving",
+  "club_team", "award", "certification", "responsibility", "feedback",
+  "interest", "constraint", "reflection", "other",
+]);
+export const EvidenceClaimStateSchema = z.enum(["fact", "user_confirmed_inference", "unconfirmed_inference"]);
+export const EvidenceVerificationSchema = z.enum(["self_reported", "artifact_attached", "third_party_attested"]);
+export const CareerVisibilitySchema = z.enum([
+  "private", "advisor_only", "guardian_visible", "packet_selectable", "public",
+]);
+
+export const CareerEvidenceRefSchema = z.strictObject({
+  id: z.string().min(1),
+  kind: z.enum(["file", "url", "note", "credential", "attestation"]),
+  label: z.string().min(1).max(300),
+  digest: z.string().regex(/^[a-f0-9]{64}$/).nullable().default(null),
+  locator: z.string().max(2000).default(""),
+});
+
+export const CareerEventSchema = z.strictObject({
+  id: z.string().uuid(),
+  sequence: z.number().int().positive(),
+  occurredAt: z.string().datetime(),
+  capturedAt: z.string().datetime(),
+  category: CareerEventCategorySchema,
+  title: z.string().min(1).max(300),
+  description: z.string().min(1).max(20_000),
+  originalSource: z.string().max(20_000).default(""),
+  claimState: EvidenceClaimStateSchema,
+  verification: EvidenceVerificationSchema,
+  skills: z.array(z.strictObject({
+    name: z.string().min(1).max(200),
+    state: EvidenceClaimStateSchema,
+    source: z.enum(["user", "import", "ai_suggestion"]),
+  })).default([]),
+  measurableResult: z.string().max(2000).default(""),
+  collaborators: z.array(z.string().min(1).max(300)).default([]),
+  context: z.string().max(5000).default(""),
+  confidence: z.number().min(0).max(1),
+  tags: z.array(z.string().min(1).max(100)).default([]),
+  occupationCodes: z.array(z.string().min(1).max(30)).default([]),
+  evidence: z.array(CareerEvidenceRefSchema).default([]),
+  visibility: CareerVisibilitySchema.default("private"),
+  supersedesEventId: z.string().uuid().nullable().default(null),
+  correctionReason: z.string().max(2000).default(""),
+  previousHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
+  hash: z.string().regex(/^[a-f0-9]{64}$/),
+});
+
+export const CareerLedgerSchema = z.strictObject({
+  schemaVersion: z.literal(CAREER_LEDGER_SCHEMA_VERSION),
+  ledgerId: z.string().uuid(),
+  ownerId: z.string().min(1),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  events: z.array(CareerEventSchema),
+});
+
+export type CareerEvent = z.infer<typeof CareerEventSchema>;
+export type CareerLedger = z.infer<typeof CareerLedgerSchema>;
+export type CareerEventInput = Omit<CareerEvent, "id" | "sequence" | "capturedAt" | "previousHash" | "hash">;
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function sha256(value: unknown): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical(value)));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function random(size: number): Uint8Array { const value = new Uint8Array(size); crypto.getRandomValues(value); return value; }
+
+export function createCareerLedger(ownerId: string, now = new Date()): CareerLedger {
+  const timestamp = now.toISOString();
+  return CareerLedgerSchema.parse({
+    schemaVersion: CAREER_LEDGER_SCHEMA_VERSION,
+    ledgerId: crypto.randomUUID(), ownerId, createdAt: timestamp, updatedAt: timestamp, events: [],
+  });
+}
+
+/** Append-only: corrections are new events linked to the event they supersede. */
+export async function appendCareerEvent(ledger: CareerLedger, input: CareerEventInput, now = new Date()): Promise<CareerLedger> {
+  const parsed = CareerLedgerSchema.parse(ledger);
+  if (input.supersedesEventId && !parsed.events.some((event) => event.id === input.supersedesEventId)) {
+    throw new Error("A correction must reference an event in this ledger.");
+  }
+  if (input.supersedesEventId && !input.correctionReason.trim()) {
+    throw new Error("A correction must explain why it supersedes the earlier event.");
+  }
+  const previousHash = parsed.events.at(-1)?.hash ?? null;
+  const withoutHash: Omit<CareerEvent, "hash"> = {
+    ...input, id: crypto.randomUUID(), sequence: parsed.events.length + 1,
+    capturedAt: now.toISOString(), previousHash,
+  };
+  const event = CareerEventSchema.parse({ ...withoutHash, hash: await sha256(withoutHash) });
+  return CareerLedgerSchema.parse({ ...parsed, updatedAt: now.toISOString(), events: [...parsed.events, event] });
+}
+
+export async function verifyCareerLedger(ledger: CareerLedger): Promise<{ valid: boolean; errors: string[] }> {
+  const parsed = CareerLedgerSchema.safeParse(ledger);
+  if (!parsed.success) return { valid: false, errors: ["Ledger schema validation failed."] };
+  const errors: string[] = [];
+  let previousHash: string | null = null;
+  const ids = new Set<string>();
+  for (const [index, event] of parsed.data.events.entries()) {
+    if (event.sequence !== index + 1) errors.push(`Event ${event.id} has an invalid sequence.`);
+    if (event.previousHash !== previousHash) errors.push(`Event ${event.id} breaks the hash chain.`);
+    const { hash, ...withoutHash } = event;
+    if (await sha256(withoutHash) !== hash) errors.push(`Event ${event.id} failed its integrity check.`);
+    if (event.supersedesEventId && !ids.has(event.supersedesEventId)) errors.push(`Event ${event.id} supersedes a missing or later event.`);
+    ids.add(event.id); previousHash = hash;
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function currentCareerEvents(ledger: CareerLedger): CareerEvent[] {
+  const superseded = new Set(ledger.events.flatMap((event) => event.supersedesEventId ? [event.supersedesEventId] : []));
+  return ledger.events.filter((event) => !superseded.has(event.id));
+}
+
+export async function createDisclosurePacket(ledger: CareerLedger, eventIds: readonly string[]) {
+  const selected = currentCareerEvents(ledger).filter((event) => eventIds.includes(event.id) && event.visibility !== "private");
+  const events = selected.map(({ originalSource: _privateSource, collaborators: _privatePeople, ...safe }) => safe);
+  const body = { schemaVersion: 1, sourceLedgerId: ledger.ledgerId, createdAt: new Date().toISOString(), events };
+  return { ...body, checksum: await sha256(body) };
+}
+
+export const EncryptedCareerBackupSchema = z.strictObject({
+  format: z.literal("resume-foundry-career-vault"), version: z.literal(1),
+  kdf: z.literal("PBKDF2-SHA256"), iterations: z.number().int().min(100_000),
+  salt: z.string(), iv: z.string(), ciphertext: z.string(),
+});
+export type EncryptedCareerBackup = z.infer<typeof EncryptedCareerBackupSchema>;
+
+const subtle = globalThis.crypto.subtle;
+const bytes = (value: string) => new TextEncoder().encode(value);
+const b64 = (value: Uint8Array) => {
+  let binary = ""; for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+};
+const unb64 = (value: string) => {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+};
+
+async function deriveKey(passphrase: string, salt: Uint8Array, iterations: number) {
+  const material = await subtle.importKey("raw", bytes(passphrase), "PBKDF2", false, ["deriveKey"]);
+  return subtle.deriveKey({ name: "PBKDF2", hash: "SHA-256", salt: new Uint8Array(salt), iterations }, material,
+    { name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]);
+}
+
+export async function exportEncryptedCareerLedger(ledger: CareerLedger, passphrase: string): Promise<EncryptedCareerBackup> {
+  if (passphrase.length < 12) throw new Error("Use a backup passphrase of at least 12 characters.");
+  const integrity = await verifyCareerLedger(ledger); if (!integrity.valid) throw new Error(integrity.errors.join(" "));
+  const salt = random(16); const iv = random(12); const iterations = 310_000;
+  const key = await deriveKey(passphrase, salt, iterations);
+  const plaintext = bytes(JSON.stringify({ ledger, checksum: await sha256(ledger) }));
+  const ciphertext = await subtle.encrypt({ name: "AES-GCM", iv: new Uint8Array(iv).buffer }, key, new Uint8Array(plaintext).buffer);
+  return { format: "resume-foundry-career-vault", version: 1, kdf: "PBKDF2-SHA256", iterations,
+    salt: b64(salt), iv: b64(iv), ciphertext: b64(new Uint8Array(ciphertext)) };
+}
+
+export async function importEncryptedCareerLedger(backup: unknown, passphrase: string): Promise<CareerLedger> {
+  const parsed = EncryptedCareerBackupSchema.parse(backup);
+  try {
+    const key = await deriveKey(passphrase, unb64(parsed.salt), parsed.iterations);
+    const plaintext = await subtle.decrypt(
+      { name: "AES-GCM", iv: new Uint8Array(unb64(parsed.iv)).buffer }, key,
+      new Uint8Array(unb64(parsed.ciphertext)).buffer,
+    );
+    const payload = JSON.parse(new TextDecoder().decode(plaintext)) as { ledger: unknown; checksum: string };
+    const ledger = CareerLedgerSchema.parse(payload.ledger);
+    if (await sha256(ledger) !== payload.checksum) throw new Error("Backup checksum mismatch.");
+    const integrity = await verifyCareerLedger(ledger); if (!integrity.valid) throw new Error(integrity.errors.join(" "));
+    return ledger;
+  } catch (error) {
+    if (error instanceof z.ZodError) throw error;
+    throw new Error("Career backup could not be decrypted or failed integrity verification.");
+  }
+}

--- a/lib/career-vault.ts
+++ b/lib/career-vault.ts
@@ -1,0 +1,52 @@
+import { CareerLedgerSchema, type CareerLedger } from "./career-ledger";
+
+const DB_NAME = "resume-foundry-career-vault";
+const DB_VERSION = 1;
+const STORE = "ledgers";
+const ACTIVE = "active";
+
+function openVault(): Promise<IDBDatabase> {
+  if (typeof indexedDB === "undefined") return Promise.reject(new Error("Encrypted career vault storage is unavailable in this browser."));
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => { if (!request.result.objectStoreNames.contains(STORE)) request.result.createObjectStore(STORE); };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Career vault could not be opened."));
+  });
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Career vault operation failed."));
+  });
+}
+
+export async function loadCareerLedger(): Promise<CareerLedger | null> {
+  const db = await openVault();
+  try {
+    const value = await requestResult(db.transaction(STORE, "readonly").objectStore(STORE).get(ACTIVE));
+    return value ? CareerLedgerSchema.parse(value) : null;
+  } finally { db.close(); }
+}
+
+export async function saveCareerLedger(ledger: CareerLedger): Promise<void> {
+  const parsed = CareerLedgerSchema.parse(ledger); const db = await openVault();
+  try {
+    const transaction = db.transaction(STORE, "readwrite");
+    transaction.objectStore(STORE).put(parsed, ACTIVE);
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error ?? new Error("Career vault write failed."));
+      transaction.onabort = () => reject(transaction.error ?? new Error("Career vault write was aborted."));
+    });
+  } finally { db.close(); }
+}
+
+export async function deleteCareerLedger(): Promise<void> {
+  const db = await openVault();
+  try { await requestResult(db.transaction(STORE, "readwrite").objectStore(STORE).delete(ACTIVE)); }
+  finally { db.close(); }
+}
+
+export const careerVaultDatabaseName = DB_NAME;


### PR DESCRIPTION
## Summary
- add a versioned append-only career evidence ledger with correction/supersession links
- separate facts, user-confirmed inferences, and unconfirmed AI suggestions
- add hash-chain verification and selective disclosure packets
- add browser IndexedDB custody plus AES-256-GCM/PBKDF2 encrypted portable backup and restore
- add a Career Ledger UI for private lifelong capture and recovery exports

## Verification
- 75/75 tests
- lint
- typecheck
- production build

## Scope honesty
This is the local-first custody and evidence foundation for #26. Optional cross-device sync, age-of-majority re-consent, BLS/O*NET path intelligence, and independent youth/privacy review remain open and are not claimed here.