### PR TITLE
Add reminders, interview prep, and least-privilege OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Required. Get a key at https://platform.claude.com/
-ANTHROPIC_API_KEY=sk-ant-...
+# Anthropic generation (existing feature)
+ANTHROPIC_API_KEY=
 
-# Optional. Defaults to claude-opus-5.
-RESUME_FOUNDRY_ANTHROPIC_MODEL=claude-opus-5
-
-# Optional. Required only for the USAJOBS connector.
-USAJOBS_API_KEY=
-USAJOBS_USER_AGENT=you@example.com
+# Optional Google email/calendar OAuth. Secrets stay server-side.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3000/api/connections/google/callback
+# Generate: node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'))"
+RESUME_FOUNDRY_CONNECTION_KEY=

--- a/app/api/connections/google/callback/route.ts
+++ b/app/api/connections/google/callback/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { exchangeGoogleCode, googleOAuthConfig, openConnection, sealConnection, stateMatches, type GoogleTokenSet, type OAuthTransaction } from "@/lib/google-oauth";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url); const jar = await cookies();
+  try {
+    const error = url.searchParams.get("error"); if (error) throw new Error(`Google authorization was not completed (${error}).`);
+    const code = url.searchParams.get("code"); const state = url.searchParams.get("state"); const sealed = jar.get("rf_google_oauth")?.value;
+    if (!code || !state || !sealed) throw new Error("Google callback is missing required authorization state.");
+    const config = googleOAuthConfig(); const transaction = openConnection<OAuthTransaction>(sealed, config.encryptionKey);
+    if (Date.now() - transaction.createdAt > 600_000 || !stateMatches(transaction.state, state)) throw new Error("Google authorization state is invalid or expired.");
+    const tokens = await exchangeGoogleCode(config, code, transaction);
+    jar.set("rf_google_connection", sealConnection({ tokens, features: transaction.features }, config.encryptionKey), { httpOnly: true, secure: process.env.NODE_ENV === "production", sameSite: "lax", path: "/", maxAge: 60 * 60 * 24 * 90 });
+    jar.delete("rf_google_oauth"); return NextResponse.redirect(new URL("/?google=connected", request.url));
+  } catch (error) {
+    jar.delete("rf_google_oauth"); const redirect = new URL("/", request.url); redirect.searchParams.set("google", "error");
+    redirect.searchParams.set("reason", error instanceof Error ? error.message : "Google connection failed."); return NextResponse.redirect(redirect);
+  }
+}
+
+export type StoredGoogleConnection = { tokens: GoogleTokenSet; features: string[] };

--- a/app/api/connections/google/disconnect/route.ts
+++ b/app/api/connections/google/disconnect/route.ts
@@ -1,0 +1,4 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function POST() { const jar = await cookies(); jar.delete("rf_google_connection"); jar.delete("rf_google_oauth"); return NextResponse.json({ connected: false }); }

--- a/app/api/connections/google/start/route.ts
+++ b/app/api/connections/google/start/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createOAuthTransaction, googleAuthorizationUrl, googleOAuthConfig, parseGoogleFeatures, sealConnection } from "@/lib/google-oauth";
+
+export async function GET(request: Request) {
+  try {
+    const config = googleOAuthConfig(); const features = parseGoogleFeatures(new URL(request.url).searchParams.get("features"));
+    const transaction = createOAuthTransaction(features); const jar = await cookies();
+    jar.set("rf_google_oauth", sealConnection(transaction, config.encryptionKey), { httpOnly: true, secure: process.env.NODE_ENV === "production", sameSite: "lax", path: "/api/connections/google", maxAge: 600 });
+    return NextResponse.redirect(googleAuthorizationUrl(config, transaction));
+  } catch (error) { return NextResponse.json({ error: error instanceof Error ? error.message : "Google connection failed." }, { status: 503 }); }
+}

--- a/app/api/connections/google/status/route.ts
+++ b/app/api/connections/google/status/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { googleOAuthConfig, openConnection } from "@/lib/google-oauth";
+import type { StoredGoogleConnection } from "../callback/route";
+
+export async function GET() {
+  const sealed = (await cookies()).get("rf_google_connection")?.value;
+  if (!sealed) return NextResponse.json({ connected: false, configured: configured() });
+  try {
+    const value = openConnection<StoredGoogleConnection>(sealed, googleOAuthConfig().encryptionKey);
+    return NextResponse.json({ connected: true, configured: true, features: value.features,
+      scopes: value.tokens.scope.split(" "), expiresAt: new Date(value.tokens.obtainedAt + value.tokens.expires_in * 1000).toISOString(),
+      hasRefreshToken: Boolean(value.tokens.refresh_token) });
+  } catch { return NextResponse.json({ connected: false, configured: configured(), error: "Stored Google connection is unavailable or invalid." }, { status: 409 }); }
+}
+
+function configured() { try { googleOAuthConfig(); return true; } catch { return false; } }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import { DictationButton } from "@/components/SpeechControls";
 import { JobInbox } from "@/components/JobInbox";
 import { ApplicationTracker } from "@/components/ApplicationTracker";
 import { CareerLedger } from "@/components/CareerLedger";
+import { Connections } from "@/components/Connections";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -704,6 +705,8 @@ export default function Home() {
         </div>
 
         <CareerLedger />
+
+        <Connections />
 
         <ApplicationTracker
           result={result}

--- a/components/ApplicationTracker.tsx
+++ b/components/ApplicationTracker.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import type { TailorResult } from "@/lib/schema";
 import { createJobSnapshot } from "@/lib/job-inbox";
-import { allowedTransitions, applicationAnalytics, createApplicationPacket, createApplicationRecord, transitionApplication, type ApplicationRecord, type ApplicationState } from "@/lib/applications";
+import { allowedTransitions, applicationAnalytics, approveReminder, buildInterviewPrep, createApplicationPacket, createApplicationRecord, dismissReminder, transitionApplication, type ApplicationRecord, type ApplicationState } from "@/lib/applications";
 import { loadApplications, loadJobInbox, saveApplications } from "@/lib/storage";
 import { ToolButton } from "@/components/ui";
 import { GuidedHandoff } from "@/components/GuidedHandoff";
@@ -12,6 +12,7 @@ export function ApplicationTracker({ result, profile, job }: { result: TailorRes
   const [records, setRecords] = useState<ApplicationRecord[]>(() => loadApplications());
   const [message, setMessage] = useState("");
   const [handoff, setHandoff] = useState<ApplicationRecord | null>(null);
+  const [prep, setPrep] = useState<ReturnType<typeof buildInterviewPrep> | null>(null);
   const analytics = applicationAnalytics(records);
 
   async function prepare() {
@@ -28,6 +29,11 @@ export function ApplicationTracker({ result, profile, job }: { result: TailorRes
     saveApplications(next); setRecords(next);
   }
 
+  function updateReminder(record: ApplicationRecord, reminderId: string, action: "approve" | "dismiss") {
+    const updated = action === "approve" ? approveReminder(record, reminderId) : dismissReminder(record, reminderId);
+    const next = records.map((entry) => entry.id === record.id ? updated : entry); saveApplications(next); setRecords(next);
+  }
+
   return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="application-tracker-heading">
     <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 id="application-tracker-heading" className="font-display text-xl font-semibold text-paper">Application tracker</h2><p className="text-[11px] text-ink-400">Each packet keeps the exact job, profile, résumé, cover letter, and checksums used.</p></div><ToolButton onClick={() => void prepare()}>Prepare immutable packet</ToolButton></div>
     {message && <p role="status" className="mt-2 text-xs text-brass-300">{message}</p>}
@@ -36,8 +42,11 @@ export function ApplicationTracker({ result, profile, job }: { result: TailorRes
     </div>
     {records.length > 0 && <div className="mt-4 overflow-x-auto"><table className="w-full min-w-[44rem] text-left text-xs"><thead className="text-ink-400"><tr><th className="p-2">Role</th><th className="p-2">State</th><th className="p-2">Packet</th><th className="p-2">Next valid state</th></tr></thead><tbody>{records.map((record) => <tr key={record.id} className="border-t border-ink-700"><td className="p-2 text-paper">{record.packet.jobSnapshot.title} @ {record.packet.jobSnapshot.company}</td><td className="p-2 text-brass-300">{record.state.replaceAll("_", " ")}</td><td className="p-2 font-mono text-[10px] text-ink-400">v{record.packet.version} · {record.packet.checksums.packet.slice(0, 12)}…</td><td className="p-2"><select aria-label={`Move ${record.packet.jobSnapshot.title} to next state`} value="" onChange={(event) => void move(record, event.target.value as ApplicationState)} className="rounded border border-ink-700 bg-ink-950 p-1"><option value="" disabled>Choose…</option>{allowedTransitions(record.state).map((state) => <option key={state} value={state}>{state.replaceAll("_", " ")}</option>)}</select></td></tr>)}</tbody></table></div>}
     {records.length > 0 && <div className="mt-3 flex flex-wrap gap-2">{records.map((record) => <ToolButton key={record.id} onClick={() => setHandoff(record)}>Guided handoff: {record.packet.jobSnapshot.title}</ToolButton>)}</div>}
+    {records.flatMap((record) => record.reminders ?? []).length > 0 && <div className="mt-4 rounded-lg border border-ink-700 bg-ink-950 p-3"><h3 className="text-sm font-semibold text-paper">User-approved reminders</h3>{records.flatMap((record) => (record.reminders ?? []).map((reminder) => ({ record, reminder }))).map(({ record, reminder }) => <div key={reminder.id} className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs"><span className="text-ink-300">{record.packet.jobSnapshot.title}: {reminder.kind.replaceAll("_", " ")} · {new Date(reminder.dueAt).toLocaleString()} · <strong>{reminder.status}</strong></span>{reminder.status === "suggested" && <span className="flex gap-2"><ToolButton onClick={() => updateReminder(record, reminder.id, "approve")}>Approve</ToolButton><ToolButton onClick={() => updateReminder(record, reminder.id, "dismiss")}>Dismiss</ToolButton></span>}</div>)}</div>}
+    {records.some((record) => ["recruiter_response", "interviewing", "offer"].includes(record.state)) && <div className="mt-3 flex flex-wrap gap-2">{records.filter((record) => ["recruiter_response", "interviewing", "offer"].includes(record.state)).map((record) => <ToolButton key={record.id} onClick={() => setPrep(buildInterviewPrep(record))}>Interview prep: {record.packet.jobSnapshot.title}</ToolButton>)}</div>}
     <details className="mt-4"><summary className="cursor-pointer text-xs text-ink-300">Analytics detail</summary><div className="mt-2 grid gap-2 text-[11px] text-ink-400 md:grid-cols-2"><pre className="overflow-auto rounded bg-ink-950 p-2">Applications/week {JSON.stringify(analytics.applicationsPerWeek, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Source effectiveness {JSON.stringify(analytics.sourceEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Resume versions {JSON.stringify(analytics.resumeVersionEffectiveness, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Missing skills {JSON.stringify(analytics.skillsMostOftenMissing, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Roles needing attention {JSON.stringify(analytics.rolesNeedingAttention, null, 2)}</pre><pre className="overflow-auto rounded bg-ink-950 p-2">Average response hours {JSON.stringify(analytics.averageResponseHours)}</pre></div></details>
     {handoff && <GuidedHandoff record={handoff} onClose={() => setHandoff(null)} />}
+    {prep && <div role="dialog" aria-modal="true" aria-labelledby="interview-prep-title" className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4"><div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded-xl border border-ink-600 bg-ink-950 p-5"><div className="flex justify-between gap-3"><div><h3 id="interview-prep-title" className="font-display text-xl text-paper">Interview prep · {prep.role}</h3><p className="text-xs text-ink-400">Frozen packet v{prep.packetVersion} · {prep.packetChecksum.slice(0, 12)}…</p></div><ToolButton onClick={() => setPrep(null)}>Close</ToolButton></div><h4 className="mt-4 text-sm font-semibold text-brass-300">Evidence stories</h4><ul className="mt-2 list-disc pl-5 text-xs text-ink-300">{prep.evidenceStories.map((item) => <li key={item.requirement}><strong>{item.requirement}:</strong> {item.evidence.join("; ")}</li>)}</ul><h4 className="mt-4 text-sm font-semibold text-brass-300">Honest gaps</h4><ul className="mt-2 list-disc pl-5 text-xs text-ink-300">{prep.honestGaps.map((item) => <li key={item.gap}><strong>{item.gap}:</strong> {item.advice}</li>)}</ul><h4 className="mt-4 text-sm font-semibold text-brass-300">Questions to prepare</h4><ul className="mt-2 list-disc pl-5 text-xs text-ink-300">{prep.questionsToPrepare.map((question) => <li key={question}>{question}</li>)}</ul></div></div>}
   </section>;
 }
 

--- a/components/Connections.tsx
+++ b/components/Connections.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ToolButton } from "@/components/ui";
+
+type Status = { connected: boolean; configured: boolean; features?: string[]; scopes?: string[]; error?: string };
+export function Connections() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [features, setFeatures] = useState<string[]>(["email_alerts"]);
+  useEffect(() => { void fetch("/api/connections/google/status").then((response) => response.json()).then(setStatus).catch(() => setStatus({ connected: false, configured: false, error: "Connection status unavailable." })); }, []);
+  const toggle = (feature: string) => setFeatures((current) => current.includes(feature) ? current.filter((item) => item !== feature) : [...current, feature]);
+  async function disconnect() { const response = await fetch("/api/connections/google/disconnect", { method: "POST" }); setStatus(await response.json() as Status); }
+  return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="connections-heading"><h2 id="connections-heading" className="font-display text-xl font-semibold text-paper">Email & calendar connections</h2><p className="text-[11px] text-ink-400">Choose only the permissions you need. Tokens remain encrypted and unavailable to browser scripts.</p>
+    <p role="status" className="mt-2 text-xs text-brass-300">{status === null ? "Checking connection…" : status.connected ? `Connected: ${status.features?.join(", ")}` : status.configured ? "Configured but not connected." : "Not configured on this server."} {status?.error}</p>
+    {!status?.connected && <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-ink-300">{[["email_alerts", "Read job-alert email"], ["email_drafts", "Create email drafts"], ["calendar_events", "Manage your interview events"]].map(([value, label]) => <label key={value} className="flex items-center gap-2"><input type="checkbox" checked={features.includes(value)} onChange={() => toggle(value)}/>{label}</label>)}<a aria-disabled={!status?.configured || !features.length} className={`rounded border border-ink-600 px-3 py-2 ${status?.configured && features.length ? "text-paper" : "pointer-events-none text-ink-600"}`} href={`/api/connections/google/start?features=${encodeURIComponent(features.join(","))}`}>Connect Google</a></div>}
+    {status?.connected && <div className="mt-3"><ToolButton onClick={() => void disconnect()}>Disconnect</ToolButton></div>}
+  </section>;
+}

--- a/docs/GOOGLE_CONNECTIONS.md
+++ b/docs/GOOGLE_CONNECTIONS.md
@@ -1,0 +1,20 @@
+# Google email and calendar connection
+
+Resume Foundry implements the server-side OAuth 2.0 authorization-code flow with PKCE and a ten-minute, authenticated state transaction. OAuth client credentials and token material are never returned to browser JavaScript. The stored connection is AES-256-GCM sealed with `RESUME_FOUNDRY_CONNECTION_KEY` in an HttpOnly, SameSite cookie.
+
+The user chooses features incrementally:
+
+- `email_alerts`: Gmail read-only, for alert ingestion.
+- `email_drafts`: Gmail compose, for drafts only—this does not grant direct send permission.
+- `calendar_events`: Calendar events owned by the user, rather than access to every calendar setting.
+
+Configure the four variables in `.env.example`, register the exact callback URI with Google, then open `/api/connections/google/start?features=email_alerts`, adding comma-separated features only when requested. `/api/connections/google/status` reports connectivity and scopes but never returns tokens. POST `/api/connections/google/disconnect` removes stored connection state.
+
+This is a single-browser controlled-demo custody model. A public multi-user deployment must move encrypted refresh tokens into authenticated, tenant-isolated server storage, add provider revocation on disconnect, and complete Google's verification requirements. It must not claim those controls from this local composition.
+
+Primary references:
+
+- Google OAuth web-server flow: https://developers.google.com/identity/protocols/oauth2/web-server
+- Google OAuth security practices: https://developers.google.com/identity/protocols/oauth2/resources/best-practices
+- Gmail scopes: https://developers.google.com/workspace/gmail/api/auth/scopes
+- Calendar scopes: https://developers.google.com/workspace/calendar/api/auth

--- a/lib/applications.test.ts
+++ b/lib/applications.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applicationAnalytics, createApplicationPacket, createApplicationRecord, transitionApplication } from "./applications";
+import { applicationAnalytics, approveReminder, buildInterviewPrep, createApplicationPacket, createApplicationRecord, dismissReminder, transitionApplication } from "./applications";
 import { createJobSnapshot } from "./job-inbox";
 import type { TailorResult } from "./schema";
 
@@ -31,5 +31,20 @@ describe("immutable application packets", () => {
     const analytics = applicationAnalytics([submitted]);
     expect(analytics).toMatchObject({ responseRate: 0, interviewConversionRate: 0 });
     expect(Object.keys(analytics)).toEqual(expect.arrayContaining(["applicationsPerWeek", "sourceEffectiveness", "resumeVersionEffectiveness", "averageResponseHours", "skillsMostOftenMissing", "companiesAwaitingFollowUp", "rolesNeedingAttention"]));
+  });
+  it("suggests state-bound reminders but never schedules without user approval", async () => {
+    const submitted = await transitionApplication(createApplicationRecord(await packet()), "submitted", new Date("2026-01-02T00:00:00Z"));
+    expect(submitted.reminders[0]).toMatchObject({ kind: "follow_up", status: "suggested", approvedAt: null, dueAt: "2026-01-09T00:00:00.000Z" });
+    expect(submitted.followUpAt).toBeNull();
+    const scheduled = approveReminder(submitted, submitted.reminders[0].id, new Date("2026-01-02T01:00:00Z"));
+    expect(scheduled.reminders[0].status).toBe("scheduled"); expect(scheduled.followUpAt).toBe("2026-01-09T00:00:00.000Z");
+    expect(dismissReminder(scheduled, scheduled.reminders[0].id).followUpAt).toBeNull();
+  });
+  it("builds interview preparation from the immutable submitted packet only", async () => {
+    let record = await transitionApplication(createApplicationRecord(await packet()), "submitted");
+    record = await transitionApplication(record, "recruiter_response"); record = await transitionApplication(record, "interviewing");
+    const prep = buildInterviewPrep(record); const originalRole = prep.role;
+    result.gap_analysis.push({ gap: "Live profile mutation", advice: "Must not leak" });
+    expect(buildInterviewPrep(record)).toEqual(prep); expect(prep.role).toBe(originalRole); expect(prep.packetChecksum).toBe(record.packet.checksums.packet);
   });
 });

--- a/lib/applications.ts
+++ b/lib/applications.ts
@@ -31,6 +31,15 @@ export interface ApplicationPacket {
 }
 
 export interface ApplicationEvent { at: string; type: string; detail: string }
+export interface ApplicationReminder {
+  id: string;
+  kind: "follow_up" | "interview_prep";
+  dueAt: string;
+  status: "suggested" | "scheduled" | "completed" | "dismissed";
+  createdAt: string;
+  approvedAt: string | null;
+  note: string;
+}
 export interface ApplicationRecord {
   id: string;
   packet: ApplicationPacket;
@@ -48,6 +57,7 @@ export interface ApplicationRecord {
   documentLinks: string[];
   emailLinks: string[];
   calendarLinks: string[];
+  reminders: ApplicationReminder[];
 }
 
 function canonical(value: unknown): string {
@@ -82,7 +92,45 @@ export async function createApplicationPacket(input: {
 }
 
 export function createApplicationRecord(packet: ApplicationPacket): ApplicationRecord {
-  return { id: crypto.randomUUID(), packet: structuredClone(packet), packetHistory: [], state: "ready", timeline: [{ at: packet.createdAt, type: "packet.created", detail: `Packet v${packet.version} created` }], notes: [], contacts: [], interviewDates: [], followUpAt: null, compensation: "", referral: "", rejectionReason: "", nextAction: "Review and approve submission", documentLinks: [], emailLinks: [], calendarLinks: [] };
+  return { id: crypto.randomUUID(), packet: structuredClone(packet), packetHistory: [], state: "ready", timeline: [{ at: packet.createdAt, type: "packet.created", detail: `Packet v${packet.version} created` }], notes: [], contacts: [], interviewDates: [], followUpAt: null, compensation: "", referral: "", rejectionReason: "", nextAction: "Review and approve submission", documentLinks: [], emailLinks: [], calendarLinks: [], reminders: [] };
+}
+
+function suggestedReminder(next: ApplicationState, now: Date): ApplicationReminder | null {
+  const days = next === "submitted" ? 7 : next === "recruiter_response" ? 2 : next === "interviewing" ? 1 : null;
+  if (days === null) return null;
+  const due = new Date(now); due.setUTCDate(due.getUTCDate() + days);
+  const kind = next === "interviewing" ? "interview_prep" : "follow_up";
+  return { id: crypto.randomUUID(), kind, dueAt: due.toISOString(), status: "suggested", createdAt: now.toISOString(), approvedAt: null,
+    note: kind === "interview_prep" ? "Prepare from the exact submitted packet." : "Review and approve this follow-up reminder." };
+}
+
+export function approveReminder(record: ApplicationRecord, reminderId: string, now = new Date()): ApplicationRecord {
+  const updated = structuredClone(record); const reminder = updated.reminders.find((item) => item.id === reminderId);
+  if (!reminder || reminder.status !== "suggested") throw new Error("Only a suggested reminder can be approved.");
+  reminder.status = "scheduled"; reminder.approvedAt = now.toISOString();
+  updated.followUpAt = reminder.kind === "follow_up" ? reminder.dueAt : updated.followUpAt;
+  updated.timeline.push({ at: now.toISOString(), type: "reminder.approved", detail: `${reminder.kind} at ${reminder.dueAt}` });
+  return updated;
+}
+
+export function dismissReminder(record: ApplicationRecord, reminderId: string, now = new Date()): ApplicationRecord {
+  const updated = structuredClone(record); const reminder = updated.reminders.find((item) => item.id === reminderId);
+  if (!reminder || !["suggested", "scheduled"].includes(reminder.status)) throw new Error("Reminder is already terminal.");
+  reminder.status = "dismissed"; if (updated.followUpAt === reminder.dueAt) updated.followUpAt = null;
+  updated.timeline.push({ at: now.toISOString(), type: "reminder.dismissed", detail: reminder.kind }); return updated;
+}
+
+export function buildInterviewPrep(record: ApplicationRecord) {
+  const packet = structuredClone(record.packet);
+  return {
+    packetId: packet.id, packetVersion: packet.version, packetChecksum: packet.checksums.packet,
+    role: packet.jobSnapshot.title, company: packet.jobSnapshot.company,
+    boundAt: packet.submittedAt ?? packet.createdAt,
+    evidenceStories: packet.tailoredResult.requirement_evidence.filter((item) => item.state === "proven" || item.state === "partially_supported").map((item) => ({ requirement: item.requirement, evidence: item.evidence })),
+    honestGaps: packet.tailoredResult.gap_analysis.map((item) => ({ ...item })),
+    questionsToPrepare: packet.tailoredResult.requirement_evidence.map((item) => `How would you demonstrate: ${item.requirement}?`),
+    questionsToAsk: [`What would success in the first 90 days look like for ${packet.jobSnapshot.title}?`, "Which requirements matter most during the first six months?"],
+  };
 }
 
 export function allowedTransitions(state: ApplicationState): readonly ApplicationState[] { return TRANSITIONS[state]; }
@@ -92,6 +140,7 @@ export async function transitionApplication(record: ApplicationRecord, next: App
   const updated = structuredClone(record);
   updated.state = next;
   updated.timeline.push({ at: now.toISOString(), type: "application.transition", detail: `${record.state} -> ${next}` });
+  const reminder = suggestedReminder(next, now); if (reminder) updated.reminders.push(reminder);
   if (next === "submitted") {
     updated.packetHistory.push(structuredClone(updated.packet));
     const { checksums: _oldChecksums, ...packetBody } = updated.packet;

--- a/lib/google-oauth.test.ts
+++ b/lib/google-oauth.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOAuthTransaction, exchangeGoogleCode, googleAuthorizationUrl, googleOAuthConfig, GOOGLE_SCOPES, openConnection, parseGoogleFeatures, sealConnection, stateMatches } from "./google-oauth";
+
+const key = Buffer.alloc(32, 7);
+const config = { clientId: "client", clientSecret: "secret", redirectUri: "http://localhost:3000/api/connections/google/callback", encryptionKey: key };
+describe("Google OAuth boundary", () => {
+  it("fails closed without every server-side secret", () => {
+    expect(() => googleOAuthConfig({})).toThrow(/not configured/);
+    expect(() => googleOAuthConfig({ GOOGLE_OAUTH_CLIENT_ID: "x", GOOGLE_OAUTH_CLIENT_SECRET: "y", GOOGLE_OAUTH_REDIRECT_URI: "http://localhost", RESUME_FOUNDRY_CONNECTION_KEY: "bad" })).toThrow(/32 bytes/);
+  });
+  it("requests only explicitly selected feature scopes with PKCE and state", () => {
+    const transaction = createOAuthTransaction(parseGoogleFeatures("email_alerts,calendar_events"), 1);
+    const url = new URL(googleAuthorizationUrl(config, transaction));
+    expect(url.searchParams.get("scope")?.split(" ")).toEqual([GOOGLE_SCOPES.email_alerts, GOOGLE_SCOPES.calendar_events]);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256"); expect(url.searchParams.get("state")).toBe(transaction.state);
+    expect(url.searchParams.get("include_granted_scopes")).toBe("false");
+  });
+  it("authenticates encrypted server-side connection state and rejects tampering", () => {
+    const sealed = sealConnection({ refresh: "never-client-visible" }, key);
+    expect(sealed).not.toContain("never-client-visible"); expect(openConnection(sealed, key)).toEqual({ refresh: "never-client-visible" });
+    const parts = sealed.split("."); parts[2] = `${parts[2][0] === "A" ? "B" : "A"}${parts[2].slice(1)}`;
+    expect(() => openConnection(parts.join("."), key)).toThrow(/authenticated/);
+    expect(stateMatches("same", "same")).toBe(true); expect(stateMatches("same", "other")).toBe(false);
+  });
+  it("exchanges authorization code with verifier and validates granted scopes", async () => {
+    const transaction = createOAuthTransaction(["email_drafts"]);
+    const request = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(String(init?.body)).toContain(`code_verifier=${transaction.verifier}`);
+      return new Response(JSON.stringify({ access_token: "access", refresh_token: "refresh", expires_in: 3600, scope: GOOGLE_SCOPES.email_drafts, token_type: "Bearer" }), { status: 200 });
+    });
+    expect((await exchangeGoogleCode(config, "code", transaction, request as typeof fetch)).refresh_token).toBe("refresh");
+  });
+});

--- a/lib/google-oauth.ts
+++ b/lib/google-oauth.ts
@@ -1,0 +1,75 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+export type GoogleFeature = "email_alerts" | "email_drafts" | "calendar_events";
+export const GOOGLE_SCOPES: Record<GoogleFeature, string> = {
+  email_alerts: "https://www.googleapis.com/auth/gmail.readonly",
+  email_drafts: "https://www.googleapis.com/auth/gmail.compose",
+  calendar_events: "https://www.googleapis.com/auth/calendar.events.owned",
+};
+
+export interface GoogleOAuthConfig { clientId: string; clientSecret: string; redirectUri: string; encryptionKey: Buffer }
+export interface OAuthTransaction { state: string; verifier: string; features: GoogleFeature[]; createdAt: number }
+export interface GoogleTokenSet { access_token: string; refresh_token?: string; expires_in: number; scope: string; token_type: string; obtainedAt: number }
+
+export function googleOAuthConfig(env: Partial<Record<string, string | undefined>> = process.env): GoogleOAuthConfig {
+  const clientId = env.GOOGLE_OAUTH_CLIENT_ID?.trim(); const clientSecret = env.GOOGLE_OAUTH_CLIENT_SECRET?.trim();
+  const redirectUri = env.GOOGLE_OAUTH_REDIRECT_URI?.trim(); const encodedKey = env.RESUME_FOUNDRY_CONNECTION_KEY?.trim();
+  if (!clientId || !clientSecret || !redirectUri || !encodedKey) throw new Error("Google connection is not configured.");
+  const encryptionKey = Buffer.from(encodedKey, "base64url");
+  if (encryptionKey.length !== 32) throw new Error("RESUME_FOUNDRY_CONNECTION_KEY must decode to exactly 32 bytes.");
+  return { clientId, clientSecret, redirectUri, encryptionKey };
+}
+
+export function parseGoogleFeatures(value: string | null): GoogleFeature[] {
+  const requested = [...new Set((value ?? "").split(",").filter(Boolean))];
+  if (!requested.length || requested.some((entry) => !(entry in GOOGLE_SCOPES))) throw new Error("Choose at least one supported Google connection feature.");
+  return requested as GoogleFeature[];
+}
+
+export function createOAuthTransaction(features: GoogleFeature[], now = Date.now()): OAuthTransaction {
+  return { state: randomBytes(32).toString("base64url"), verifier: randomBytes(48).toString("base64url"), features: [...features], createdAt: now };
+}
+
+export function googleAuthorizationUrl(config: GoogleOAuthConfig, transaction: OAuthTransaction): string {
+  const challenge = createHash("sha256").update(transaction.verifier).digest("base64url");
+  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  url.search = new URLSearchParams({ client_id: config.clientId, redirect_uri: config.redirectUri, response_type: "code",
+    scope: transaction.features.map((feature) => GOOGLE_SCOPES[feature]).join(" "), state: transaction.state,
+    code_challenge: challenge, code_challenge_method: "S256", access_type: "offline", prompt: "consent",
+    include_granted_scopes: "false" }).toString();
+  return url.toString();
+}
+
+export function stateMatches(expected: string, actual: string): boolean {
+  const left = Buffer.from(expected); const right = Buffer.from(actual);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function sealConnection(value: unknown, key: Buffer): string {
+  const iv = randomBytes(12); const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(value), "utf8"), cipher.final()]);
+  return `${iv.toString("base64url")}.${cipher.getAuthTag().toString("base64url")}.${ciphertext.toString("base64url")}`;
+}
+
+export function openConnection<T>(sealed: string, key: Buffer): T {
+  try {
+    const [iv, tag, ciphertext] = sealed.split(".").map((part) => Buffer.from(part, "base64url"));
+    if (!iv || !tag || !ciphertext) throw new Error("invalid envelope");
+    const decipher = createDecipheriv("aes-256-gcm", key, iv); decipher.setAuthTag(tag);
+    return JSON.parse(Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8")) as T;
+  } catch { throw new Error("Stored connection could not be authenticated."); }
+}
+
+export async function exchangeGoogleCode(config: GoogleOAuthConfig, code: string, transaction: OAuthTransaction,
+  request: typeof fetch = fetch): Promise<GoogleTokenSet> {
+  const response = await request("https://oauth2.googleapis.com/token", { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ client_id: config.clientId, client_secret: config.clientSecret, code, code_verifier: transaction.verifier,
+      grant_type: "authorization_code", redirect_uri: config.redirectUri }) });
+  if (!response.ok) throw new Error(`Google token exchange failed (${response.status}).`);
+  const value = await response.json() as Partial<GoogleTokenSet>;
+  if (!value.access_token || !value.expires_in || !value.scope || value.token_type !== "Bearer") throw new Error("Google returned an incomplete token response.");
+  const granted = new Set(value.scope.split(" ")); const expected = transaction.features.map((feature) => GOOGLE_SCOPES[feature]);
+  if (expected.some((scope) => !granted.has(scope))) throw new Error("Google did not grant every requested scope.");
+  return { access_token: value.access_token, refresh_token: value.refresh_token, expires_in: value.expires_in,
+    scope: value.scope, token_type: value.token_type, obtainedAt: Date.now() };
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -175,7 +175,10 @@ export function deleteJobSnapshot(id: string): JobPostingSnapshot[] {
 
 export function loadApplications(): ApplicationRecord[] {
   if (!canStore()) return [];
-  try { return JSON.parse(localStorage.getItem(APPLICATIONS_KEY) ?? "[]") as ApplicationRecord[]; }
+  try {
+    const records = JSON.parse(localStorage.getItem(APPLICATIONS_KEY) ?? "[]") as ApplicationRecord[];
+    return records.map((record) => ({ ...record, packetHistory: record.packetHistory ?? [], reminders: record.reminders ?? [] }));
+  }
   catch { return []; }
 }
 


### PR DESCRIPTION
Closes #16

## Delivered
- state-transition reminder suggestions that remain inactive until explicit user approval
- immutable-packet interview prep with packet ID/version/checksum provenance
- Google OAuth authorization-code flow with PKCE, authenticated state, exact incremental scopes, server-side AES-256-GCM token sealing, status, and disconnect endpoints
- controlled-demo configuration and production-boundary documentation

## Evidence
- 81/81 tests
- lint
- typecheck
- production build

## Honest boundary
A live Google consent requires deployer-owned OAuth credentials and Google verification. Missing configuration fails closed; no connected status is fabricated.