### PR TITLE
Add synthetic sensitive-work attestation security profile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,7 @@ import { JobInbox } from "@/components/JobInbox";
 import { ApplicationTracker } from "@/components/ApplicationTracker";
 import { CareerLedger } from "@/components/CareerLedger";
 import { Connections } from "@/components/Connections";
+import { SensitiveAttestationBoundary } from "@/components/SensitiveAttestationBoundary";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -705,6 +706,8 @@ export default function Home() {
         </div>
 
         <CareerLedger />
+
+        <SensitiveAttestationBoundary />
 
         <Connections />
 

--- a/components/SensitiveAttestationBoundary.tsx
+++ b/components/SensitiveAttestationBoundary.tsx
@@ -1,0 +1,8 @@
+export function SensitiveAttestationBoundary() {
+  return <section className="rounded-xl border border-amber-500/40 bg-amber-950/10 p-4" aria-labelledby="attestation-boundary-heading">
+    <h2 id="attestation-boundary-heading" className="font-display text-xl font-semibold text-paper">Sensitive-work employer attestations</h2>
+    <p className="mt-2 text-sm font-semibold text-amber-300">Cryptographically verified employer attestation — not a security clearance or government endorsement.</p>
+    <p className="mt-2 text-xs text-ink-300">A future authorized issuer may confirm a narrowly approved, unclassified predicate without disclosing a program, customer, contract, duties, technology, location, facility, clearance level, or classified content. Current clearance and access verification remains with the applicable government and employing organization process.</p>
+    <p className="mt-2 text-[10px] text-ink-500">Synthetic profile only. No real clearance data, DISS integration, or public pilot is enabled.</p>
+  </section>;
+}

--- a/docs/SENSITIVE_WORK_ATTESTATION_THREAT_MODEL.md
+++ b/docs/SENSITIVE_WORK_ATTESTATION_THREAT_MODEL.md
@@ -1,0 +1,21 @@
+# Synthetic sensitive-work employer attestation
+
+This profile lets an authorized employer issue a minimal acknowledgment of bounded sensitive-work participation. It is **not a security clearance, eligibility determination, access authorization, DISS record, classified-work description, or government endorsement**.
+
+## Threats and controls
+
+- **Issuer impersonation:** verifier accepts only a registered issuer/key authorized for each disclosed claim type and within its validity window.
+- **Holder theft/substitution:** every credential binds a per-credential holder public key; each presentation requires its signature.
+- **Replay:** verifier supplies an unpredictable nonce; presentation binds nonce, audience, expiry, credential, and disclosed digests; nonce consumption is mandatory.
+- **Over-disclosure:** the strict claim schema rejects program, customer, contract, clearance, technology, location, and duty details. Salted disclosures reveal only selected predicates.
+- **Correlation:** holders should use a separate subject binding/key for each issuer relationship. Verifiers receive no hidden disclosure salts or subject binding unless explicitly selected.
+- **Stale/revoked credentials:** verifier checks credential validity, credential status, issuer-key status, and rotation history.
+- **Verifier collusion:** audience-bound presentations cannot be replayed to a second audience; policy and legal controls are still needed because a verifier can copy information it legitimately sees.
+- **Misleading clearance claims:** UI/output must use the exact label “Cryptographically verified employer attestation — not a security clearance or government endorsement.”
+- **Forged résumé evidence:** the issuer can bind a salted commitment to an exact frozen packet assertion; altered text does not match.
+
+## Synthetic-only boundary
+
+The `RF-SENSITIVE-SD-1` profile is a Resume Foundry test profile using Ed25519 and salted disclosure digests. It is not claimed to be interoperable with an external government or commercial credential wallet. Real deployment remains blocked until authorized government security, classification, legal, privacy, records, accessibility, and cryptographic reviewers approve the exact vocabulary, issuer authorization process, status service, key custody, and presentation profile. No classified or real clearance data belongs in this repository or its tests.
+
+Standards/boundary references: W3C VC Data Model 2.0 (https://www.w3.org/TR/vc-data-model/), DCSA DISS FAQ (https://www.dcsa.mil/Systems-Applications/Defense-Information-System-for-Security-DISS/FAQs-DISS/), DCSA adjudication FAQ (https://www.dcsa.mil/Trust-Decision-Adjudications/FAQS-Trust-Decision-Adjudications/), and SF-312 (https://www.archives.gov/isoo/security-forms/sf312.pdf).

--- a/lib/sensitive-attestation.test.ts
+++ b/lib/sensitive-attestation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { assertionCommitment, createSensitivePresentation, generateAttestationKeyPair, issueSensitiveCredential, SensitiveClaimSchema, verifySensitivePresentation, type CredentialStatus, type TrustRegistry } from "./sensitive-attestation";
+
+const issuer = generateAttestationKeyPair(); const holder = generateAttestationKeyPair();
+const registry: TrustRegistry = { issuers: [{ issuerId: "synthetic-employer", keyId: "2026-a", publicKey: issuer.publicKey, allowedClaims: ["sensitiveWorkParticipation", "attestationScope", "subjectBinding", "assertionCommitment"], validFrom: "2025-01-01T00:00:00Z", validUntil: "2030-01-01T00:00:00Z", status: "active" }] };
+const status: CredentialStatus = { revokedCredentialIds: new Set() };
+const claim = { sensitiveWorkParticipation: true as const, attestationScope: "accomplishment" as const, subjectBinding: "a".repeat(64), assertionCommitment: assertionCommitment("Led an approved sensitive-work effort", "packet-salt") };
+function credential() { return issueSensitiveCredential({ claim, issuerId: "synthetic-employer", keyId: "2026-a", issuerPrivateKey: issuer.privateKey, holderPublicKey: holder.publicKey, validFrom: new Date("2026-01-01"), validUntil: new Date("2028-01-01") }); }
+function presentation(credential_ = credential(), nonce = "verifier-nonce") { return createSensitivePresentation({ credential: credential_, disclose: ["sensitiveWorkParticipation", "attestationScope", "assertionCommitment"], holderPrivateKey: holder.privateKey, audience: "prospective-employer", nonce, expiresAt: new Date("2026-06-01T00:05:00Z") }); }
+function verifyOne(presentation_ = presentation(), overrides: Partial<Parameters<typeof verifySensitivePresentation>[0]> = {}) { const used = new Set<string>(); return verifySensitivePresentation({ presentation: presentation_, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), consumeNonce: (nonce) => { if (used.has(nonce)) return false; used.add(nonce); return true; }, requiredClaims: ["sensitiveWorkParticipation"], ...overrides }); }
+
+describe("sensitive-work employer attestation", () => {
+  it("rejects forbidden or detailed fields at schema boundary", () => {
+    for (const forbidden of ["programName", "customer", "contract", "clearanceLevel", "technology", "location", "duties"]) expect(() => SensitiveClaimSchema.parse({ ...claim, [forbidden]: "SECRET" })).toThrow();
+  });
+  it("selectively discloses approved predicates without hidden subject binding", () => {
+    const shown = presentation(); const result = verifyOne(shown);
+    expect(result.valid).toBe(true); expect(result.claims).not.toHaveProperty("subjectBinding");
+    expect(JSON.stringify(shown)).not.toContain(claim.subjectBinding); expect(result.label).toContain("not a security clearance");
+  });
+  it("binds presentations to holder, audience, nonce, and expiry", () => {
+    expect(() => verifyOne(presentation(), { expectedAudience: "attacker" })).toThrow(/audience/);
+    expect(() => verifyOne(presentation(), { expectedNonce: "other" })).toThrow(/nonce/);
+    expect(() => verifyOne(presentation(), { now: new Date("2026-06-01T00:06:00Z") })).toThrow(/expired/);
+    const tampered = presentation(); tampered.holderSignature = `${tampered.holderSignature.slice(0, -2)}AA`; expect(() => verifyOne(tampered)).toThrow(/Holder/);
+  });
+  it("rejects replay through verifier nonce consumption", () => {
+    const shown = presentation(); const used = new Set<string>(); const consumeNonce = (nonce: string) => { if (used.has(nonce)) return false; used.add(nonce); return true; };
+    const base = { presentation: shown, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), consumeNonce };
+    expect(verifySensitivePresentation(base).valid).toBe(true); expect(() => verifySensitivePresentation(base)).toThrow(/already consumed/);
+  });
+  it("enforces issuer authorization, revocation, and key rotation", () => {
+    const shown = presentation(); const restricted: TrustRegistry = { issuers: [{ ...registry.issuers[0], allowedClaims: ["sensitiveWorkParticipation"] }] };
+    expect(() => verifyOne(shown, { registry: restricted })).toThrow(/not authorized/);
+    expect(() => verifyOne(shown, { status: { revokedCredentialIds: new Set([shown.credential.id]) } })).toThrow(/revoked/);
+    expect(() => verifyOne(shown, { registry: { issuers: [{ ...registry.issuers[0], status: "revoked" }] } })).toThrow(/not trusted/);
+    expect(verifyOne(shown, { registry: { issuers: [{ ...registry.issuers[0], status: "retired" }] } }).valid).toBe(true);
+  });
+  it("verifies a salted commitment to the exact frozen resume assertion", () => {
+    const result = verifyOne(); expect(result.claims.assertionCommitment).toBe(assertionCommitment("Led an approved sensitive-work effort", "packet-salt"));
+    expect(result.claims.assertionCommitment).not.toBe(assertionCommitment("Changed assertion", "packet-salt"));
+  });
+});

--- a/lib/sensitive-attestation.ts
+++ b/lib/sensitive-attestation.ts
@@ -1,0 +1,68 @@
+import { createHash, generateKeyPairSync, randomBytes, randomUUID, sign, verify } from "node:crypto";
+import { z } from "zod";
+
+export const SensitiveClaimSchema = z.strictObject({
+  sensitiveWorkParticipation: z.literal(true),
+  assuranceCategory: z.string().regex(/^[A-Z0-9_-]{1,32}$/).optional(),
+  timeRange: z.string().regex(/^\d{4}(?:-\d{4})?$/).optional(),
+  attestationScope: z.enum(["employment", "accomplishment", "role-family"]),
+  subjectBinding: z.string().regex(/^[a-f0-9]{64}$/),
+  assertionCommitment: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+});
+export type SensitiveClaim = z.infer<typeof SensitiveClaimSchema>;
+type ClaimKey = keyof SensitiveClaim;
+export type IssuerKey = { issuerId: string; keyId: string; publicKey: string; allowedClaims: ClaimKey[]; validFrom: string; validUntil: string; status: "active" | "retired" | "revoked" };
+export type TrustRegistry = { issuers: IssuerKey[] };
+type Disclosure = [salt: string, key: ClaimKey, value: unknown];
+export type SensitiveCredential = { profile: "RF-SENSITIVE-SD-1"; id: string; issuerId: string; keyId: string; validFrom: string; validUntil: string; holderPublicKey: string; digests: string[]; signature: string; disclosures: Disclosure[] };
+export type SensitivePresentation = { credential: Omit<SensitiveCredential, "disclosures">; disclosures: Disclosure[]; audience: string; nonce: string; expiresAt: string; holderSignature: string };
+export type CredentialStatus = { revokedCredentialIds: Set<string> };
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") { const record = value as Record<string, unknown>; return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`; }
+  return JSON.stringify(value);
+}
+const digest = (value: unknown) => createHash("sha256").update(canonical(value)).digest("hex");
+export function assertionCommitment(assertion: string, salt: string) { return digest({ assertion: assertion.normalize("NFKC").trim(), salt }); }
+export function generateAttestationKeyPair() { return generateKeyPairSync("ed25519", { publicKeyEncoding: { type: "spki", format: "pem" }, privateKeyEncoding: { type: "pkcs8", format: "pem" } }); }
+
+export function issueSensitiveCredential(input: { claim: SensitiveClaim; issuerId: string; keyId: string; issuerPrivateKey: string; holderPublicKey: string; validFrom: Date; validUntil: Date }): SensitiveCredential {
+  const claim = SensitiveClaimSchema.parse(input.claim); if (input.validUntil <= input.validFrom) throw new Error("Credential validity window is invalid.");
+  const disclosures = Object.entries(claim).map(([key, value]) => [randomBytes(16).toString("base64url"), key as ClaimKey, value] satisfies Disclosure);
+  const unsigned = { profile: "RF-SENSITIVE-SD-1" as const, id: randomUUID(), issuerId: input.issuerId, keyId: input.keyId,
+    validFrom: input.validFrom.toISOString(), validUntil: input.validUntil.toISOString(), holderPublicKey: input.holderPublicKey,
+    digests: disclosures.map(digest).sort() };
+  return { ...unsigned, signature: sign(null, Buffer.from(canonical(unsigned)), input.issuerPrivateKey).toString("base64url"), disclosures };
+}
+
+export function createSensitivePresentation(input: { credential: SensitiveCredential; disclose: ClaimKey[]; holderPrivateKey: string; audience: string; nonce: string; expiresAt: Date }): SensitivePresentation {
+  if (!input.audience.trim() || !input.nonce.trim()) throw new Error("Audience and verifier nonce are required.");
+  const { disclosures: _all, ...credential } = input.credential;
+  const disclosures = input.credential.disclosures.filter((item) => input.disclose.includes(item[1]));
+  const proof = { credentialId: credential.id, disclosureDigests: disclosures.map(digest).sort(), audience: input.audience, nonce: input.nonce, expiresAt: input.expiresAt.toISOString() };
+  return { credential, disclosures, audience: input.audience, nonce: input.nonce, expiresAt: input.expiresAt.toISOString(), holderSignature: sign(null, Buffer.from(canonical(proof)), input.holderPrivateKey).toString("base64url") };
+}
+
+export function verifySensitivePresentation(input: { presentation: SensitivePresentation; registry: TrustRegistry; status: CredentialStatus; expectedAudience: string; expectedNonce: string; now?: Date; consumeNonce: (nonce: string) => boolean; requiredClaims?: ClaimKey[] }) {
+  const now = input.now ?? new Date(); const presentation = input.presentation; const credential = presentation.credential;
+  if (presentation.audience !== input.expectedAudience || presentation.nonce !== input.expectedNonce) throw new Error("Presentation audience or nonce mismatch.");
+  if (new Date(presentation.expiresAt) <= now) throw new Error("Presentation expired.");
+  if (!input.consumeNonce(presentation.nonce)) throw new Error("Presentation nonce was already consumed.");
+  if (input.status.revokedCredentialIds.has(credential.id)) throw new Error("Credential is revoked.");
+  if (new Date(credential.validFrom) > now || new Date(credential.validUntil) <= now) throw new Error("Credential is outside its validity window.");
+  const key = input.registry.issuers.find((entry) => entry.issuerId === credential.issuerId && entry.keyId === credential.keyId);
+  if (!key || key.status === "revoked" || new Date(key.validFrom) > now || new Date(key.validUntil) <= now) throw new Error("Issuer key is not trusted for this time and scope.");
+  const { signature, ...unsigned } = credential;
+  if (!verify(null, Buffer.from(canonical(unsigned)), key.publicKey, Buffer.from(signature, "base64url"))) throw new Error("Issuer signature is invalid.");
+  for (const disclosure of presentation.disclosures) {
+    if (!credential.digests.includes(digest(disclosure))) throw new Error("Disclosure is not bound to the credential.");
+    if (!key.allowedClaims.includes(disclosure[1])) throw new Error(`Issuer is not authorized for ${disclosure[1]}.`);
+  }
+  const claims = Object.fromEntries(presentation.disclosures.map(([, name, value]) => [name, value])); SensitiveClaimSchema.partial().parse(claims);
+  for (const required of input.requiredClaims ?? []) if (!(required in claims)) throw new Error(`Required claim ${required} was not disclosed.`);
+  const proof = { credentialId: credential.id, disclosureDigests: presentation.disclosures.map(digest).sort(), audience: presentation.audience, nonce: presentation.nonce, expiresAt: presentation.expiresAt };
+  if (!verify(null, Buffer.from(canonical(proof)), credential.holderPublicKey, Buffer.from(presentation.holderSignature, "base64url"))) throw new Error("Holder binding proof is invalid.");
+  return { valid: true as const, credentialId: credential.id, issuerId: credential.issuerId, claims,
+    label: "Cryptographically verified employer attestation — not a security clearance or government endorsement" };
+}


### PR DESCRIPTION
Progresses #24

## Delivered
- strict minimal claim schema rejecting program/customer/contract/clearance/duty/technology/location detail
- Ed25519 issuer and holder binding
- salted selective disclosures, audience/nonce/expiry binding, replay consumption
- issuer trust scope, credential revocation, key rotation, frozen-assertion commitment
- explicit UI and threat model: employer attestation, not clearance or government endorsement

## Evidence
- 100/100 tests
- lint
- typecheck
- production build
- npm audit: zero vulnerabilities

## Not claimed
RF-SENSITIVE-SD-1 is a synthetic local profile. External wallet interoperability and authorized government/security/legal/privacy review remain open, so this PR intentionally does not close #24.