### PR TITLE
Harden CI and pin Actions v7 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,24 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: npm

--- a/lib/workflow-policy.test.ts
+++ b/lib/workflow-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+
+describe("CI workflow policy", () => {
+  it("pins third-party actions and uses least privilege", async () => {
+    const workflow = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+    const actions = [...workflow.matchAll(/uses:\s*([^\s#]+)/gu)].map((match) => match[1]);
+    expect(actions.length).toBeGreaterThan(0);
+    for (const action of actions) expect(action).toMatch(/@[a-f0-9]{40}$/u);
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(workflow).toContain("persist-credentials: false");
+    expect(workflow).toContain("timeout-minutes: 15");
+    expect(workflow).toMatch(/on:\s*\n\s+push:[\s\S]*?\n\s+pull_request:\s*\n\s+branches:/u);
+    expect(workflow).not.toMatch(/concurrency:[\s\S]*?pull_request:/u);
+  });
+});


### PR DESCRIPTION
Supersedes #8 and #9.

- pins checkout v7.0.1 and setup-node v7.0.0 to upstream-verified 40-hex commits
- disables checkout credential persistence
- adds contents:read least privilege
- adds concurrency cancellation and a 15-minute timeout
- adds a policy regression test

Evidence: 111/111 tests, lint, typecheck, build, npm audit 0 vulnerabilities.