### PR TITLE
Fix career ledger privacy and recovery invariants

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -782,9 +782,9 @@ export default function Home() {
                 Past runs <span className="text-ink-400">(stored only in this browser)</span>
               </h2>
               <ToolButton
-                onClick={() => {
+                onClick={async () => {
                   if (confirm("Delete your saved profile and all history from this browser?")) {
-                    clearAllData();
+                    await clearAllData();
                     setHistory([]);
                     setSavePoints([]);
                     setResume("");

--- a/components/CareerLedger.tsx
+++ b/components/CareerLedger.tsx
@@ -5,7 +5,7 @@ import {
   appendCareerEvent, createCareerLedger, exportEncryptedCareerLedger, importEncryptedCareerLedger,
   currentCareerEvents, deleteCareerEvent, type CareerLedger as Ledger,
 } from "@/lib/career-ledger";
-import { deleteCareerLedger, hasCareerLedger, loadCareerLedger, saveCareerLedger } from "@/lib/career-vault";
+import { deleteCareerLedger, hasCareerLedger, loadCareerLedger, migrateLegacyPlaintextCareerLedger, saveCareerLedger } from "@/lib/career-vault";
 import { ToolButton } from "@/components/ui";
 
 export function CareerLedger() {
@@ -13,6 +13,7 @@ export function CareerLedger() {
   const [title, setTitle] = useState(""); const [description, setDescription] = useState("");
   const [category, setCategory] = useState<"project" | "coursework" | "paid_work" | "volunteering" | "other">("project");
   const [passphrase, setPassphrase] = useState(""); const [status, setStatus] = useState("Checking encrypted career vault…");
+  const [legacyDetected, setLegacyDetected] = useState(false);
   const [vaultExists, setVaultExists] = useState(false); const [ageBand, setAgeBand] = useState<"minor" | "adult" | "unspecified">("unspecified");
   useEffect(() => { void hasCareerLedger().then((exists) => { setVaultExists(exists); setStatus(exists ? "Encrypted ledger found. Enter its passphrase to unlock." : "No ledger yet. Choose a passphrase to create one."); }).catch((error: unknown) => setStatus(error instanceof Error ? error.message : "Vault unavailable.")); }, []);
 
@@ -22,7 +23,11 @@ export function CareerLedger() {
   }
   async function unlock() {
     try { const saved = await loadCareerLedger(passphrase); setLedger(saved); setStatus(saved ? "Career ledger decrypted and integrity-checked." : "No ledger found."); }
-    catch (error) { setStatus(error instanceof Error ? error.message : "Unlock failed."); }
+    catch (error) { const message = error instanceof Error ? error.message : "Unlock failed."; setLegacyDetected(message.includes("legacy plaintext")); setStatus(message); }
+  }
+  async function migrateLegacy() {
+    try { const saved = await migrateLegacyPlaintextCareerLedger(passphrase); setLedger(saved); setVaultExists(true); setLegacyDetected(false); setStatus("Legacy vault explicitly migrated, encrypted, and integrity-checked."); }
+    catch (error) { setStatus(error instanceof Error ? error.message : "Legacy migration failed."); }
   }
   async function add() {
     if (!ledger || !title.trim() || !description.trim()) { setStatus("Create the ledger and enter a title and description first."); return; }
@@ -51,7 +56,7 @@ export function CareerLedger() {
   return <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-4" aria-labelledby="career-ledger-heading">
     <div className="flex flex-wrap items-start justify-between gap-3"><div><h2 id="career-ledger-heading" className="font-display text-xl font-semibold text-paper">Career ledger</h2><p className="text-[11px] text-ink-400">Keep projects, work, learning, volunteering, caregiving, and evidence for future uses you cannot predict yet.</p></div></div>
     <p role="status" className="mt-2 text-xs text-brass-300">{status}</p>
-    {!ledger && <div className="mt-3 flex flex-wrap items-center gap-2"><input type="password" value={passphrase} onChange={(event) => setPassphrase(event.target.value)} placeholder="Vault passphrase (12+ characters)" aria-label="Career vault passphrase" className="min-w-64 rounded border border-ink-700 bg-ink-950 p-2 text-xs"/>{!vaultExists && <select aria-label="Age privacy setting" value={ageBand} onChange={(event) => setAgeBand(event.target.value as typeof ageBand)} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"><option value="unspecified">Age not specified</option><option value="minor">Under age of majority</option><option value="adult">Adult</option></select>}<ToolButton onClick={() => void (vaultExists ? unlock() : ensureLedger())}>{vaultExists ? "Unlock ledger" : "Create encrypted ledger"}</ToolButton><label className="cursor-pointer rounded border border-ink-600 px-3 py-2 text-xs text-paper">Restore encrypted backup<input type="file" accept="application/json" className="sr-only" onChange={(event) => void restore(event.target.files?.[0])}/></label></div>}
+    {!ledger && <div className="mt-3 flex flex-wrap items-center gap-2"><input type="password" value={passphrase} onChange={(event) => setPassphrase(event.target.value)} placeholder="Vault passphrase (12+ characters)" aria-label="Career vault passphrase" className="min-w-0 w-full rounded border border-ink-700 bg-ink-950 p-2 text-xs sm:w-auto sm:min-w-64"/>{!vaultExists && <select aria-label="Age privacy setting" value={ageBand} onChange={(event) => setAgeBand(event.target.value as typeof ageBand)} className="max-w-full rounded border border-ink-700 bg-ink-950 p-2 text-xs"><option value="unspecified">Age not specified</option><option value="minor">Under age of majority</option><option value="adult">Adult</option></select>}<ToolButton onClick={() => void (vaultExists ? unlock() : ensureLedger())}>{vaultExists ? "Unlock ledger" : "Create encrypted ledger"}</ToolButton>{legacyDetected && <ToolButton onClick={() => void migrateLegacy()}>Explicitly migrate legacy vault</ToolButton>}<label className="cursor-pointer rounded border border-ink-600 px-3 py-2 text-xs text-paper">Restore encrypted backup<input type="file" accept="application/json" className="sr-only" onChange={(event) => void restore(event.target.files?.[0])}/></label></div>}
     {ledger && <>
       <div className="mt-3 grid gap-2 md:grid-cols-[10rem_1fr_2fr_auto]"><select aria-label="Entry category" value={category} onChange={(event) => setCategory(event.target.value as typeof category)} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"><option value="project">Project</option><option value="coursework">Coursework</option><option value="paid_work">Paid work</option><option value="volunteering">Volunteering</option><option value="other">Other</option></select><input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="What happened?" maxLength={300} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"/><input value={description} onChange={(event) => setDescription(event.target.value)} placeholder="What did you do, learn, or accomplish?" maxLength={20000} className="rounded border border-ink-700 bg-ink-950 p-2 text-xs"/><ToolButton onClick={() => void add()}>Append entry</ToolButton></div>
       {ledger.privacy.ageBand === "minor" && <p className="mt-3 rounded border border-amber-600/40 p-2 text-xs text-amber-300">Minor privacy mode: private by default, no public profile, optional guardian assistance does not transfer ownership. Control review due {ledger.privacy.ageOfMajorityReviewDueAt ? new Date(ledger.privacy.ageOfMajorityReviewDueAt).toLocaleDateString() : "when adulthood is reached"}.</p>}

--- a/lib/career-ledger.test.ts
+++ b/lib/career-ledger.test.ts
@@ -49,11 +49,18 @@ describe("career evidence ledger", () => {
   it("selectively discloses only eligible events and removes private source details", async () => {
     let ledger = await appendCareerEvent(createCareerLedger("owner-1"), event());
     ledger = await appendCareerEvent(ledger, event({ title: "Private reflection", visibility: "private" }));
+    ledger = await appendCareerEvent(ledger, event({ title: "Advisor note", visibility: "advisor_only" }));
+    ledger = await appendCareerEvent(ledger, event({ title: "Guardian note", visibility: "guardian_visible" }));
     const packet = await createDisclosurePacket(ledger, ledger.events.map((entry) => entry.id));
     expect(packet.events).toHaveLength(1);
     expect(packet.events[0].title).toBe("Robotics team");
     expect(packet.events[0]).not.toHaveProperty("originalSource");
     expect(packet.events[0]).not.toHaveProperty("collaborators");
+    expect(packet.events[0]).not.toHaveProperty("context");
+    expect(packet.events[0]).not.toHaveProperty("correctionReason");
+    expect(packet.events[0].evidence[0]).not.toHaveProperty("locator");
+    expect(JSON.stringify(packet)).not.toContain("Advisor note");
+    expect(JSON.stringify(packet)).not.toContain("Guardian note");
     expect(packet.checksum).toMatch(/^[a-f0-9]{64}$/);
   });
 
@@ -89,6 +96,22 @@ describe("career evidence ledger", () => {
     expect(JSON.stringify(ledger)).not.toContain("Robotics team"); expect(ledger.events.map((item) => item.title)).toEqual(["Keep me"]);
     expect(ledger.deletions[0]).toMatchObject({ eventId: removed.id, priorHash: removed.hash, reason: "Owner request" });
     expect((await verifyCareerLedger(ledger)).valid).toBe(true);
+  });
+  it("erases an entire correction lineage without resurrecting superseded content", async () => {
+    let ledger = await appendCareerEvent(createCareerLedger("owner"), event({ title: "Sensitive original" }));
+    const original = ledger.events[0];
+    ledger = await appendCareerEvent(ledger, event({ title: "Sensitive correction", supersedesEventId: original.id, correctionReason: "Corrected" }));
+    const correction = ledger.events[1];
+    ledger = await deleteCareerEvent(ledger, correction.id, "Erase the corrected item");
+    expect(currentCareerEvents(ledger)).toEqual([]);
+    expect(JSON.stringify(ledger)).not.toContain("Sensitive original");
+    expect(JSON.stringify(ledger)).not.toContain("Sensitive correction");
+    expect((await verifyCareerLedger(ledger)).valid).toBe(true);
+  });
+  it("rejects AI-suggested skills that callers attempt to promote directly to facts", async () => {
+    await expect(appendCareerEvent(createCareerLedger("owner"), event({
+      skills: [{ name: "invented credential", state: "fact", source: "ai_suggestion" }],
+    }))).rejects.toThrow(/cannot be recorded as facts/);
   });
   it("lets the owner confirm, edit, or reject AI skill mappings without upgrading them to facts", async () => {
     let ledger = await appendCareerEvent(createCareerLedger("owner"), event({ skills: [{ name: "systems thinking", state: "unconfirmed_inference", source: "ai_suggestion" }] }));

--- a/lib/career-ledger.ts
+++ b/lib/career-ledger.ts
@@ -49,6 +49,12 @@ export const CareerEventSchema = z.strictObject({
   correctionReason: z.string().max(2000).default(""),
   previousHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
   hash: z.string().regex(/^[a-f0-9]{64}$/),
+}).superRefine((event, context) => {
+  for (const [index, skill] of event.skills.entries()) {
+    if (skill.source === "ai_suggestion" && skill.state === "fact") {
+      context.addIssue({ code: "custom", path: ["skills", index, "state"], message: "AI-suggested skills cannot be recorded as facts." });
+    }
+  }
 });
 
 export const CareerPrivacySchema = z.strictObject({
@@ -160,7 +166,23 @@ export function currentCareerEvents(ledger: CareerLedger): CareerEvent[] {
 export async function deleteCareerEvent(ledger: CareerLedger, eventId: string, reason: string, now = new Date()): Promise<CareerLedger> {
   const parsed = CareerLedgerSchema.parse(ledger); const removed = parsed.events.find((event) => event.id === eventId);
   if (!removed) throw new Error("Career event not found."); if (!reason.trim()) throw new Error("Deletion reason is required.");
-  const retained = parsed.events.filter((event) => event.id !== eventId && event.supersedesEventId !== eventId);
+  // Erase the whole correction lineage. Removing only the newest correction would
+  // resurrect superseded sensitive text; removing only a root would orphan later
+  // corrections. A deletion must never make older content current again.
+  const erased = new Set([eventId]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const event of parsed.events) {
+      if ((erased.has(event.id) && event.supersedesEventId && !erased.has(event.supersedesEventId)) ||
+          (event.supersedesEventId && erased.has(event.supersedesEventId) && !erased.has(event.id))) {
+        erased.add(event.id);
+        if (event.supersedesEventId) erased.add(event.supersedesEventId);
+        changed = true;
+      }
+    }
+  }
+  const retained = parsed.events.filter((event) => !erased.has(event.id));
   const rebuilt: CareerEvent[] = []; let previousHash: string | null = null;
   for (const [index, event] of retained.entries()) {
     const { hash: _hash, ...body } = event; const withoutHash = { ...body, sequence: index + 1, previousHash };
@@ -182,8 +204,12 @@ export async function reviewInferredSkill(ledger: CareerLedger, eventId: string,
 }
 
 export async function createDisclosurePacket(ledger: CareerLedger, eventIds: readonly string[]) {
-  const selected = currentCareerEvents(ledger).filter((event) => eventIds.includes(event.id) && event.visibility !== "private");
-  const events = selected.map(({ originalSource: _privateSource, collaborators: _privatePeople, ...safe }) => safe);
+  const selected = currentCareerEvents(ledger).filter((event) => eventIds.includes(event.id) && event.visibility === "packet_selectable");
+  const events = selected.map(({ originalSource: _privateSource, collaborators: _privatePeople, context: _privateContext,
+    correctionReason: _privateCorrection, evidence, ...safe }) => ({
+    ...safe,
+    evidence: evidence.map(({ locator: _privateLocator, ...reference }) => reference),
+  }));
   const body = { schemaVersion: 1, sourceLedgerId: ledger.ledgerId, createdAt: new Date().toISOString(), events };
   return { ...body, checksum: await sha256(body) };
 }

--- a/lib/career-vault.test.ts
+++ b/lib/career-vault.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { IDBFactory } from "fake-indexeddb";
 import { appendCareerEvent, createCareerLedger } from "./career-ledger";
-import { careerVaultDatabaseName, deleteCareerLedger, hasCareerLedger, loadCareerLedger, saveCareerLedger } from "./career-vault";
+import { careerVaultDatabaseName, deleteCareerLedger, hasCareerLedger, loadCareerLedger, migrateLegacyPlaintextCareerLedger, saveCareerLedger } from "./career-vault";
 
 beforeEach(() => { Object.defineProperty(globalThis, "indexedDB", { value: new IDBFactory(), configurable: true }); });
 async function rawStored() {
   const request = indexedDB.open(careerVaultDatabaseName); const db = await new Promise<IDBDatabase>((resolve, reject) => { request.onsuccess = () => resolve(request.result); request.onerror = () => reject(request.error); });
   const result = db.transaction("ledgers", "readonly").objectStore("ledgers").get("active"); const value = await new Promise<unknown>((resolve, reject) => { result.onsuccess = () => resolve(result.result); result.onerror = () => reject(result.error); }); db.close(); return value;
+}
+async function putRaw(value: unknown) {
+  await hasCareerLedger(); // creates the versioned object store in a fresh fake IDB factory
+  const request = indexedDB.open(careerVaultDatabaseName); const db = await new Promise<IDBDatabase>((resolve, reject) => { request.onsuccess = () => resolve(request.result); request.onerror = () => reject(request.error); });
+  const transaction = db.transaction("ledgers", "readwrite"); transaction.objectStore("ledgers").put(value, "active");
+  await new Promise<void>((resolve, reject) => { transaction.oncomplete = () => resolve(); transaction.onerror = () => reject(transaction.error); }); db.close();
 }
 describe("browser career vault", () => {
   it("stores only an encrypted envelope at rest and restores losslessly", async () => {
@@ -19,5 +25,19 @@ describe("browser career vault", () => {
   it("supports complete local account deletion", async () => {
     await saveCareerLedger(createCareerLedger("owner"), "long recovery phrase"); expect(await hasCareerLedger()).toBe(true);
     await deleteCareerLedger(); expect(await hasCareerLedger()).toBe(false);
+  });
+  it("rejects arbitrary plaintext vaults instead of silently trusting and re-keying them", async () => {
+    await putRaw(createCareerLedger("attacker-controlled"));
+    await expect(loadCareerLedger("any passphrase works")).rejects.toThrow(/explicit migration/);
+    await expect(migrateLegacyPlaintextCareerLedger("long recovery phrase")).rejects.toThrow(/No supported legacy/);
+  });
+  it("migrates only an explicit schema-v1 plaintext vault and immediately encrypts it", async () => {
+    const current = createCareerLedger("legacy-owner");
+    const { privacy: _privacy, deletions: _deletions, ...body } = current;
+    await putRaw({ ...body, schemaVersion: 1 });
+    const migrated = await migrateLegacyPlaintextCareerLedger("long recovery phrase");
+    expect(migrated.ownerId).toBe("legacy-owner");
+    expect(JSON.stringify(await rawStored())).not.toContain("legacy-owner");
+    expect(await loadCareerLedger("long recovery phrase")).toEqual(migrated);
   });
 });

--- a/lib/career-vault.ts
+++ b/lib/career-vault.ts
@@ -34,8 +34,18 @@ export async function loadCareerLedger(passphrase: string): Promise<CareerLedger
   const value = await storedValue(); if (!value) return null;
   const encrypted = EncryptedCareerBackupSchema.safeParse(value);
   if (encrypted.success) return importEncryptedCareerLedger(encrypted.data, passphrase);
-  // One-time migration for the original plaintext-v1 browser vault. It is immediately re-encrypted.
-  const migrated = migrateCareerLedger(value); await saveCareerLedger(migrated, passphrase); return migrated;
+  throw new Error("A legacy plaintext career vault was detected. Use the explicit migration action before unlocking it.");
+}
+
+/** Explicit, one-time migration. Unknown/current plaintext objects are rejected. */
+export async function migrateLegacyPlaintextCareerLedger(passphrase: string): Promise<CareerLedger> {
+  const value = await storedValue();
+  if (!value || typeof value !== "object" || (value as { schemaVersion?: unknown }).schemaVersion !== 1) {
+    throw new Error("No supported legacy plaintext-v1 career vault was found.");
+  }
+  const migrated = migrateCareerLedger(value);
+  await saveCareerLedger(migrated, passphrase);
+  return migrated;
 }
 
 export async function saveCareerLedger(ledger: CareerLedger, passphrase: string): Promise<void> {
@@ -52,9 +62,13 @@ export async function saveCareerLedger(ledger: CareerLedger, passphrase: string)
 }
 
 export async function deleteCareerLedger(): Promise<void> {
-  const db = await openVault();
-  try { await requestResult(db.transaction(STORE, "readwrite").objectStore(STORE).delete(ACTIVE)); }
-  finally { db.close(); }
+  if (typeof indexedDB === "undefined") return;
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error("Career vault deletion failed."));
+    request.onblocked = () => reject(new Error("Career vault deletion was blocked by another open tab."));
+  });
 }
 
 export const careerVaultDatabaseName = DB_NAME;

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -4,6 +4,7 @@ import {
   clearAllData,
   deleteSavePoint,
   loadJobInbox,
+  loadHistory,
   loadSavePoints,
   saveJobInbox,
   type Session,
@@ -60,10 +61,16 @@ describe("local save points", () => {
     expect(points.at(-1)?.profile.resume).toBe("resume 3");
   });
 
-  it("erases checkpoints with the rest of the local user data", () => {
+  it("erases checkpoints with the rest of the local user data", async () => {
     addSavePoint({ resume: "private", extraInfo: "" }, session);
-    clearAllData();
+    await clearAllData();
     expect(loadSavePoints()).toEqual([]);
+  });
+  it("quarantines malformed persisted history instead of bricking every reload", () => {
+    localStorage.setItem("art:history", JSON.stringify([{ result: { broken: true } }]));
+    expect(loadHistory()).toEqual([]);
+    expect(localStorage.getItem("art:history")).toBeNull();
+    expect(localStorage.getItem("art:history:quarantine")).toContain("broken");
   });
 });
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,7 +1,9 @@
-import type { TailorResult } from "./schema";
+import { z } from "zod";
+import { TailorResultSchema, type TailorResult } from "./schema";
 import type { PrivacyMode } from "./pii";
 import { JobPostingSnapshotSchema, type JobPostingSnapshot } from "./schema";
 import type { ApplicationRecord } from "./applications";
+import { deleteCareerLedger } from "./career-vault";
 
 /**
  * Local-first persistence. The profile and history live only in this
@@ -28,15 +30,25 @@ const HISTORY_KEY = "art:history";
 const HISTORY_LIMIT = 25;
 
 const canStore = () => typeof window !== "undefined" && !!window.localStorage;
+const ProfileSchema = z.strictObject({ resume: z.string(), extraInfo: z.string(), updatedAt: z.number().finite() });
+const HistoryEntrySchema = z.strictObject({ id: z.string().min(1), createdAt: z.number().finite(), jobTitle: z.string(), company: z.string(), result: TailorResultSchema });
+const SessionSchema = z.strictObject({ jobText: z.string(), jobUrl: z.string(), jobTitle: z.string(), company: z.string(), emphasis: z.enum(["balanced", "technical", "leadership"]), privacyMode: z.enum(["protect", "review", "exact"]), result: TailorResultSchema.nullable() }).partial();
+
+function parseStored<T>(key: string, schema: z.ZodType<T>, fallback: T): T {
+  if (!canStore()) return fallback;
+  const raw = localStorage.getItem(key); if (!raw) return fallback;
+  try { return schema.parse(JSON.parse(raw)); }
+  catch {
+    // Quarantine the exact bytes for explicit recovery/export while ensuring one
+    // malformed record cannot brick every reload.
+    try { localStorage.setItem(`${key}:quarantine`, raw); localStorage.removeItem(key); } catch { /* storage may be full */ }
+    return fallback;
+  }
+}
 
 export function loadProfile(): Profile | null {
   if (!canStore()) return null;
-  try {
-    const raw = localStorage.getItem(PROFILE_KEY);
-    return raw ? (JSON.parse(raw) as Profile) : null;
-  } catch {
-    return null;
-  }
+  return parseStored(PROFILE_KEY, ProfileSchema.nullable(), null);
 }
 
 export function saveProfile(profile: Omit<Profile, "updatedAt">): void {
@@ -46,12 +58,7 @@ export function saveProfile(profile: Omit<Profile, "updatedAt">): void {
 
 export function loadHistory(): HistoryEntry[] {
   if (!canStore()) return [];
-  try {
-    const raw = localStorage.getItem(HISTORY_KEY);
-    return raw ? (JSON.parse(raw) as HistoryEntry[]) : [];
-  } catch {
-    return [];
-  }
+  return parseStored(HISTORY_KEY, HistoryEntrySchema.array(), []);
 }
 
 export function addHistory(entry: Omit<HistoryEntry, "id" | "createdAt">): HistoryEntry[] {
@@ -98,12 +105,7 @@ const APPLICATIONS_KEY = "art:applications:v1";
 
 export function loadSession(): Partial<Session> | null {
   if (!canStore()) return null;
-  try {
-    const raw = localStorage.getItem(SESSION_KEY);
-    return raw ? (JSON.parse(raw) as Partial<Session>) : null;
-  } catch {
-    return null;
-  }
+  return parseStored(SESSION_KEY, SessionSchema.nullable(), null);
 }
 
 export function saveSession(session: Session): void {
@@ -187,7 +189,7 @@ export function saveApplications(records: readonly ApplicationRecord[]): void {
   localStorage.setItem(APPLICATIONS_KEY, JSON.stringify(records));
 }
 
-export function clearAllData(): void {
+export async function clearAllData(): Promise<void> {
   if (!canStore()) return;
   localStorage.removeItem(PROFILE_KEY);
   localStorage.removeItem(HISTORY_KEY);
@@ -195,5 +197,10 @@ export function clearAllData(): void {
   localStorage.removeItem(SAVE_POINTS_KEY);
   localStorage.removeItem(JOB_INBOX_KEY);
   localStorage.removeItem(APPLICATIONS_KEY);
+  localStorage.removeItem("rf:career-last-backup");
+  for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+    const key = localStorage.key(index); if (key?.endsWith(":quarantine")) localStorage.removeItem(key);
+  }
+  await deleteCareerLedger();
   window.dispatchEvent?.(new Event("resume-foundry:data-cleared"));
 }


### PR DESCRIPTION
Fixes independently reproduced ledger/privacy defects: correction-lineage deletion no longer resurrects sensitive content; selective disclosure is explicit packet_selectable allowlist and strips private metadata/locators; AI suggestions cannot be caller-promoted to facts; plaintext vaults require explicit v1 migration; full erase deletes the IndexedDB database and backup/quarantine metadata; malformed local history is quarantined instead of bricking reload; 240px passphrase control can shrink. Includes failing-path regressions. Verification: 116/116 tests, lint, typecheck, production build, npm audit 0.