### PR TITLE
Enforce evidence references and correct market claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Resume Foundry
 
-**Honest AI resume tailoring. One profile, any job. Nothing fabricated, ever.**
+**Evidence-linked AI résumé tailoring. One profile, any job, with unsupported claims surfaced for human review.**
 
 Save your career history once, point it at any job posting (paste the text or just the URL), and get an honestly tailored, ATS-safe resume and cover letter — with a calibrated match score, a full diff of every change, a keyword gap analysis, and exports in DOCX, Markdown, plain text, and print/PDF.
 
-Powered by **Claude Opus 5** with structured outputs and adaptive thinking. Built with Next.js 16, React 19, TypeScript, and Tailwind CSS 4.
+Uses a deployment-configured Anthropic API model with structured outputs and adaptive thinking. Built with Next.js 16, React 19, TypeScript, and Tailwind CSS 4.
 
 ## Why this beats the usual tools
 
@@ -12,7 +12,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 
 | Principle | What it means here |
 |---|---|
-| **Honesty guarantee** | The model never adds a skill, title, date, or metric without evidence in your history. Keywords it *can't* honestly add are listed under "Not added — no evidence", with reasons. |
+| **Evidence discipline** | The model is instructed to cite résumé evidence and list unsupported keywords under "Not added — no evidence." Deterministic validation is being expanded; generated content still requires human review. |
 | **Transparent diff** | Every change is logged and classified: reworded, reordered, removed, or emphasized. You stay accountable for your own resume. |
 | **Real parse view** | A "What the ATS sees" tab shows the exact plain text a parser extracts — if it reads cleanly there, it reads cleanly in Workday, Greenhouse, Lever, and iCIMS. |
 | **2026-aware scoring** | Semantic matching, no keyword stuffing (modern ATS penalize it), calibrated scores with the arithmetic explained — plus an instant, deterministic keyword scan that runs in your browser before any AI. |
@@ -30,7 +30,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 - **Exports** — DOCX (ATS-safe single column), Markdown, plain text, print/PDF, one-click copy.
 - **History** — past runs stored locally, reloadable, deletable.
 - **Career Ledger** — append-only, correction-aware evidence captured across school, work, projects, volunteering, and life transitions; encrypted at rest with portable backup and age-aware privacy controls.
-- **Career-path intelligence** — provenance-labelled BLS/O*NET trend and skills data, uncertainty-aware occupation classifications, and training suggestions tied to explicit evidence gaps.
+- **Career-path intelligence foundation** — tested BLS/O*NET adapters, provenance schemas, uncertainty-aware classification, and evidence-gap-linked training logic. Product ingestion/UI wiring remains in progress.
 - **Application operating system** — job inbox, immutable application packets, pipeline tracking, reminders, interview preparation, approved handoffs, official ATS connectors, and Gmail draft creation.
 - **Agent interfaces** — bearer-authenticated HTTP/OpenAPI operations and a stdio MCP server share one permission, approval, rate-limit, persistence, and audit boundary.
 

--- a/app/api/capabilities/route.ts
+++ b/app/api/capabilities/route.ts
@@ -5,7 +5,7 @@ export const dynamic = "force-static";
 export function GET() {
   return NextResponse.json({
     service: "resume-foundry",
-    version: "1.1.0",
+    version: "1.0.0",
     privacy: {
       profilePersistence: "browser-local-storage",
       careerEvidencePersistence: "encrypted-indexeddb",

--- a/app/api/tailor/route.ts
+++ b/app/api/tailor/route.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/prompts";
-import { TailorRequestSchema, TailorResultSchema, tailorResultJsonSchema } from "@/lib/schema";
+import { assertTailorResultEvidence, HonestyValidationError, TailorRequestSchema, TailorResultSchema, tailorResultJsonSchema } from "@/lib/schema";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
@@ -97,6 +97,7 @@ export async function POST(req: NextRequest): Promise<Response> {
             .map((b) => b.text)
             .join("");
           const result = TailorResultSchema.parse(JSON.parse(text));
+          assertTailorResultEvidence(result, parsed.resume);
           send({ type: "result", data: result });
         }
       } catch (err) {
@@ -116,6 +117,9 @@ export async function POST(req: NextRequest): Promise<Response> {
 }
 
 function describeError(err: unknown): string {
+  if (err instanceof HonestyValidationError) {
+    return "The generated draft failed evidence validation and was withheld. No unverified draft was returned; review the source résumé and try again.";
+  }
   if (err instanceof Anthropic.AuthenticationError) {
     return "Invalid ANTHROPIC_API_KEY. Check .env.local.";
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -343,8 +343,8 @@ export default function Home() {
           </div>
           <div className="flex flex-col items-end gap-2 text-right">
             <Chip tone="good">🔒 Stored only in your browser</Chip>
-            <Chip tone="brass">No fabricated skills, ever</Chip>
-            <Chip tone="muted">Powered by Claude Opus 5</Chip>
+            <Chip tone="brass">Evidence-linked · human review required</Chip>
+            <Chip tone="muted">Anthropic model configured by deployment</Chip>
             <p className="max-w-[17rem] text-[11px] leading-snug text-ink-400">
               Your profile and history are saved only in this browser. When you click Forge,
               your resume and the job text are sent to Anthropic&rsquo;s API to generate the

--- a/lib/job-inbox.test.ts
+++ b/lib/job-inbox.test.ts
@@ -6,6 +6,9 @@ const input = { company: "Acme", title: "Platform Engineer", location: "Remote",
 
 describe("job inbox", () => {
   it("canonicalizes tracking URLs", () => expect(canonicalJobUrl(input.applicationUrl)).toBe("https://jobs.example.com/42"));
+  it("normalizes equivalent schemes, www hosts, default ports, and ad trackers", () => {
+    expect(canonicalJobUrl("http://www.jobs.example.com:80/42/?gclid=x&fbclid=y")).toBe("https://jobs.example.com/42");
+  });
   it("creates immutable revisions with SHA-256 content hashes", async () => {
     const first = await createJobSnapshot(input, [], new Date("2026-01-01T00:00:00Z"));
     const second = await createJobSnapshot({ ...input, description: `${description} New revision.` }, [first], new Date("2026-01-02T00:00:00Z"));
@@ -19,6 +22,13 @@ describe("job inbox", () => {
     const same = { ...first, id: crypto.randomUUID() };
     expect(duplicateKeys(first, same).sort()).toEqual(["canonicalUrl", "companyTitleLocation", "descriptionHash", "sourceId"].sort());
     expect(addJobSnapshot([first], same)).toMatchObject({ added: false, duplicateOf: first.id });
+  });
+  it("deduplicates strong source identity even when superficial imported text differs", async () => {
+    const first = await createJobSnapshot({ ...input, source: "lever", sourceId: "abc" });
+    const duplicate = await createJobSnapshot({ ...input, source: "lever", sourceId: "ABC", description: `${description} Tracking footer changed.` });
+    expect(addJobSnapshot([first], duplicate)).toMatchObject({ added: false, duplicateOf: first.id });
+    const revision = await createJobSnapshot({ ...input, source: "lever", sourceId: "abc", description: `${description} Real requirement added.` }, [first]);
+    expect(addJobSnapshot([first], revision).added).toBe(true);
   });
   it("imports quoted CSV and JSON arrays", () => {
     const csv = `company,title,location,description,url\n"Acme, Inc",Engineer,Remote,"${description}",https://example.com/job`;

--- a/lib/job-inbox.ts
+++ b/lib/job-inbox.ts
@@ -46,9 +46,11 @@ export function canonicalJobUrl(value: string): string {
   const url = new URL(value.trim());
   url.hash = "";
   for (const key of [...url.searchParams.keys()]) {
-    if (/^(utm_|ref$|source$|trk$|tracking)/i.test(key)) url.searchParams.delete(key);
+    if (/^(utm_|ref$|source$|trk$|tracking|gclid$|fbclid$)/i.test(key)) url.searchParams.delete(key);
   }
-  url.hostname = url.hostname.toLowerCase();
+  url.protocol = "https:";
+  url.hostname = url.hostname.toLowerCase().replace(/^www\./u, "");
+  if (url.port === "80" || url.port === "443") url.port = "";
   url.pathname = url.pathname.replace(/\/+$/, "") || "/";
   url.searchParams.sort();
   return url.toString();
@@ -110,7 +112,16 @@ export function addJobSnapshot(
   jobs: readonly JobPostingSnapshot[],
   candidate: JobPostingSnapshot,
 ): { jobs: JobPostingSnapshot[]; added: boolean; duplicateOf?: string } {
-  const identical = jobs.find((job) => job.contentHash === candidate.contentHash && duplicateKeys(job, candidate).length > 0);
+  const identical = jobs.find((job) => {
+    const keys = duplicateKeys(job, candidate);
+    const strongIdentity = keys.includes("sourceId") || keys.includes("canonicalUrl");
+    const descriptiveIdentity = keys.includes("companyTitleLocation") && keys.includes("descriptionHash");
+    // A deliberately created revision is retained; an independently re-imported
+    // record with the same strong identity is a duplicate even if superficial
+    // page text changed.
+    const isRevision = candidate.previousSnapshotId === job.id && candidate.revision > job.revision;
+    return !isRevision && (strongIdentity || descriptiveIdentity);
+  });
   if (identical) return { jobs: [...jobs], added: false, duplicateOf: identical.id };
   return { jobs: [candidate, ...jobs], added: true };
 }

--- a/lib/labor-market.test.ts
+++ b/lib/labor-market.test.ts
@@ -4,9 +4,12 @@ import { classifyOccupationTrend, fetchBlsSeries, fetchOnetOccupation, recommend
 const snapshot = (growth: number | null, overrides: Partial<LaborMarketSnapshot> = {}): LaborMarketSnapshot => ({ occupationCode: "15-1252", occupationTitle: "Software Developers", geography: "United States", employmentLevel: 1000, medianWage: 120000, projectedGrowthPercent: growth, annualOpenings: 100, replacementOpenings: 20, projectionStartYear: 2024, projectionEndYear: 2034, asOfDate: "2026-01-01", source: "BLS", sourceUrl: "https://www.bls.gov/emp/", uncertainty: "Projection, not a guarantee.", retrievedAt: "2026-01-01T00:00:00Z", ...overrides });
 describe("labor-market path intelligence", () => {
   it("distinguishes growth, decline, stability, transformation, and missing data", () => {
-    expect(classifyOccupationTrend(snapshot(8)).trend).toBe("growing"); expect(classifyOccupationTrend(snapshot(-3)).trend).toBe("declining");
-    expect(classifyOccupationTrend(snapshot(3, { replacementOpenings: 10 })).trend).toBe("stable"); expect(classifyOccupationTrend(snapshot(3, { replacementOpenings: 100 })).trend).toBe("transforming");
-    expect(classifyOccupationTrend(snapshot(null)).trend).toBe("insufficient_data"); expect(classifyOccupationTrend(snapshot(-3)).reasons.join(" ")).toContain("still exist");
+    const now = new Date("2026-07-31T00:00:00Z");
+    expect(classifyOccupationTrend(snapshot(8), now).trend).toBe("growing"); expect(classifyOccupationTrend(snapshot(-3), now).trend).toBe("declining");
+    expect(classifyOccupationTrend(snapshot(3, { replacementOpenings: 10 }), now).trend).toBe("stable"); expect(classifyOccupationTrend(snapshot(3, { replacementOpenings: 100 }), now).trend).toBe("transforming");
+    expect(classifyOccupationTrend(snapshot(null), now).trend).toBe("insufficient_data"); expect(classifyOccupationTrend(snapshot(-3), now).reasons.join(" ")).toContain("still exist");
+    expect(classifyOccupationTrend(snapshot(3, { employmentLevel: null }), now).trend).toBe("insufficient_data");
+    expect(classifyOccupationTrend(snapshot(8, { asOfDate: "1999-01-01" }), now)).toMatchObject({ trend: "insufficient_data" });
   });
   it("preserves BLS series provenance, geography warning, as-of date, and observations", async () => {
     const fetcher = vi.fn().mockResolvedValue(new Response(JSON.stringify({ status: "REQUEST_SUCCEEDED", Results: { series: [{ seriesID: "TEST", data: [{ year: "2026", period: "M01", value: "12.5", footnotes: [] }] }] } }), { status: 200 }));
@@ -18,6 +21,8 @@ describe("labor-market path intelligence", () => {
     const result = await fetchOnetOccupation("15-1252.00", { username: "user", password: "secret" }, fetcher);
     expect(result).toMatchObject({ source: "ONET", occupationCode: "15-1252.00", asOfDate: "2026-01-15" });
     expect(JSON.stringify(result)).not.toContain("secret"); expect((fetcher.mock.calls[0][1] as RequestInit).headers).toHaveProperty("authorization");
+    const missingDate = vi.fn().mockResolvedValue(new Response(JSON.stringify({ title: "Developer" }), { status: 200 }));
+    await expect(fetchOnetOccupation("15-1252.00", { username: "user", password: "secret" }, missingDate)).rejects.toThrow(/update date/);
   });
   it("ranks training only when it maps to an explicit evidence gap", () => {
     const resources: TrainingResource[] = [{ id: "r1", title: "Security course", provider: "Community college", sourceUrl: "https://example.edu/security", skills: ["network security"], cost: { amount: 200, currency: "USD", note: "Published tuition" }, durationHours: 40, prerequisites: ["Networking basics"], accessibility: ["captions"], accreditation: "Regional", evidenceQuality: "accredited", asOfDate: "2026-01-01" }, { id: "r2", title: "Unrelated", provider: "Provider", sourceUrl: "https://example.com/other", skills: ["pottery"], cost: { amount: 0, currency: "USD", note: "Free" }, durationHours: 2, prerequisites: [], accessibility: [], accreditation: "", evidenceQuality: "provider_claim", asOfDate: "2026-01-01" }];

--- a/lib/labor-market.ts
+++ b/lib/labor-market.ts
@@ -12,9 +12,17 @@ export type LaborMarketSnapshot = z.infer<typeof LaborMarketSnapshotSchema>;
 export type Trend = "growing" | "stable" | "transforming" | "declining" | "insufficient_data";
 
 /** Documented policy thresholds, not BLS labels or outcome guarantees. */
-export function classifyOccupationTrend(snapshot: LaborMarketSnapshot): { trend: Trend; reasons: string[] } {
+export function classifyOccupationTrend(snapshot: LaborMarketSnapshot, now = new Date()): { trend: Trend; reasons: string[] } {
   const value = LaborMarketSnapshotSchema.parse(snapshot); const growth = value.projectedGrowthPercent;
+  const ageMs = now.getTime() - new Date(`${value.asOfDate}T00:00:00Z`).getTime();
+  const missing = [
+    growth === null ? "projected growth rate" : null,
+    value.employmentLevel === null ? "current employment level" : null,
+    value.projectionStartYear === null || value.projectionEndYear === null ? "projection period" : null,
+  ].filter(Boolean);
+  if (missing.length) return { trend: "insufficient_data", reasons: [`Missing required inputs: ${missing.join(", ")}.`] };
   if (growth === null) return { trend: "insufficient_data", reasons: ["No projected growth rate was supplied."] };
+  if (ageMs > 3 * 366 * 24 * 60 * 60 * 1000) return { trend: "insufficient_data", reasons: [`Source data is stale as of ${value.asOfDate}; refresh it before using a trend label.`] };
   const replacementRate = value.employmentLevel && value.replacementOpenings !== null ? value.replacementOpenings / value.employmentLevel * 100 : null;
   if (growth <= -2) return { trend: "declining", reasons: [`Projected employment change is ${growth}%.`, value.annualOpenings ? `${value.annualOpenings} annual openings may still exist; decline does not mean zero opportunity.` : "Openings were not supplied." ] };
   if (growth >= 5) return { trend: "growing", reasons: [`Projected employment change is ${growth}%.`, value.annualOpenings !== null ? `${value.annualOpenings} annual openings are reported.` : "Openings were not supplied."] };
@@ -41,8 +49,9 @@ export async function fetchOnetOccupation(code: string, credentials: { username:
   const response = await fetcher(`https://api-v2.onetcenter.org/online/occupations/${encodeURIComponent(code)}/summary`, { headers: { authorization: `Basic ${Buffer.from(`${credentials.username}:${credentials.password}`).toString("base64")}`, accept: "application/json" } });
   if (!response.ok) throw new Error(`O*NET request failed (${response.status}).`);
   const value = await response.json() as Record<string, unknown>;
+  if (typeof value.updated !== "string" || !/^\d{4}-\d{2}-\d{2}$/u.test(value.updated)) throw new Error("O*NET response omitted a valid source update date.");
   return { source: "ONET" as const, sourceUrl: `https://www.onetonline.org/link/summary/${code}`, occupationCode: code, retrievedAt: new Date().toISOString(),
-    asOfDate: typeof value.updated === "string" ? value.updated : new Date().toISOString().slice(0, 10),
+    asOfDate: value.updated,
     uncertainty: "O*NET describes occupational characteristics; it does not guarantee an individual's fit, eligibility, hiring, wage, or outcome.", data: value };
 }
 

--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertTailorResultEvidence,
   TailorRequestSchema,
   TailorResultSchema,
   tailorResultJsonSchema,
@@ -55,6 +56,28 @@ describe("TailorResultSchema", () => {
       evidence: ["Invented Rust experience"],
     };
     expect(() => TailorResultSchema.parse(dishonest)).toThrow(/Unsupported requirements/);
+  });
+});
+
+describe("deterministic evidence boundary", () => {
+  it("accepts source-backed evidence and output references", () => {
+    const result = TailorResultSchema.parse({
+      ...VALID_RESULT,
+      keywords: { ...VALID_RESULT.keywords, added: ["CI/CD"] },
+      requirement_evidence: [{ id: "delivery", requirement: "Delivery", category: "mandatory", state: "proven",
+        evidence: ["Built CI pipelines"], tailoredText: ["Built CI pipelines"], recommendation: "" }],
+      tailored_resume_markdown: "# Jane Doe\nBuilt CI pipelines and improved CI/CD delivery.",
+    });
+    expect(() => assertTailorResultEvidence(result, "Engineer. Built CI pipelines for releases.")).not.toThrow();
+  });
+  it("withholds fabricated evidence, missing output references, and phantom added keywords", () => {
+    const result = TailorResultSchema.parse({
+      ...VALID_RESULT,
+      keywords: { ...VALID_RESULT.keywords, added: ["Kubernetes"] },
+      requirement_evidence: [{ id: "k8s", requirement: "Kubernetes", category: "mandatory", state: "proven",
+        evidence: ["Ran a 500-node Kubernetes platform"], tailoredText: ["Managed Kubernetes"], recommendation: "" }],
+    });
+    expect(() => assertTailorResultEvidence(result, "Engineer with CI pipeline experience.")).toThrow(/failed evidence validation/);
   });
 });
 

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,34 @@ export const TailorResultSchema = z.strictObject({
 
 export type TailorResult = z.infer<typeof TailorResultSchema>;
 
+export class HonestyValidationError extends Error {
+  constructor(public readonly violations: readonly string[]) {
+    super(`Generated content failed evidence validation: ${violations.join(" ")}`);
+    this.name = "HonestyValidationError";
+  }
+}
+
+const comparable = (value: string) => value.normalize("NFKC").toLocaleLowerCase().replace(/\s+/gu, " ").trim();
+
+/** Deterministic post-generation boundary for structured evidence references. */
+export function assertTailorResultEvidence(result: TailorResult, originalResume: string): void {
+  const source = comparable(originalResume);
+  const output = comparable(`${result.tailored_resume_markdown}\n${result.cover_letter_markdown}`);
+  const violations: string[] = [];
+  for (const requirement of result.requirement_evidence) {
+    for (const evidence of requirement.evidence) {
+      if (!source.includes(comparable(evidence))) violations.push(`Requirement ${requirement.id} cites evidence absent from the original résumé.`);
+    }
+    for (const text of requirement.tailoredText) {
+      if (!output.includes(comparable(text))) violations.push(`Requirement ${requirement.id} references tailored text absent from the generated documents.`);
+    }
+  }
+  for (const keyword of result.keywords.added) {
+    if (!output.includes(comparable(keyword))) violations.push(`Added keyword "${keyword}" is absent from the generated documents.`);
+  }
+  if (violations.length) throw new HonestyValidationError([...new Set(violations)]);
+}
+
 /**
  * JSON schema for the Claude structured-output format:
  * additionalProperties:false everywhere, and no numeric constraints


### PR DESCRIPTION
Addresses independent findings: deterministic post-generation evidence validation with explicit withholding; product claims no longer promise absolute non-fabrication, a fixed model, or wired labor UI; capability version matches package/OpenAPI; labor classification rejects missing/stale provenance and O*NET no longer fabricates update dates; job identity canonicalization/dedup handles trackers, schemes, www/default ports, and strong source identity while preserving deliberate revisions. Verification: 120/120 tests, lint, typecheck, production build, audit 0.