### PR TITLE
Harden sensitive-work attestation verification

### DIFF
--- a/docs/SENSITIVE_WORK_ATTESTATION_THREAT_MODEL.md
+++ b/docs/SENSITIVE_WORK_ATTESTATION_THREAT_MODEL.md
@@ -6,13 +6,13 @@ This profile lets an authorized employer issue a minimal acknowledgment of bound
 
 - **Issuer impersonation:** verifier accepts only a registered issuer/key authorized for each disclosed claim type and within its validity window.
 - **Holder theft/substitution:** every credential binds a per-credential holder public key; each presentation requires its signature.
-- **Replay:** verifier supplies an unpredictable nonce; presentation binds nonce, audience, expiry, credential, and disclosed digests; nonce consumption is mandatory.
-- **Over-disclosure:** the strict claim schema rejects program, customer, contract, clearance, technology, location, and duty details. Salted disclosures reveal only selected predicates.
+- **Replay:** verifier supplies an unpredictable nonce; presentation binds nonce, audience, expiry, credential, and disclosed digests. The verifier consumes the nonce atomically only after every signature, binding, validity, revocation, authorization, disclosure, and assertion check passes. Production deployments require a durable shared `NonceStore`; the included in-memory implementation is test/local-process only.
+- **Over-disclosure:** the strict claim schema rejects program, customer, contract, clearance, technology, location, and duty details. `assuranceCategory` accepts only governance-approved opaque identifiers (`RF-AC-001` through `RF-AC-003`); issuer-controlled strings are rejected. Salted disclosures reveal only selected predicates.
 - **Correlation:** holders should use a separate subject binding/key for each issuer relationship. Verifiers receive no hidden disclosure salts or subject binding unless explicitly selected.
-- **Stale/revoked credentials:** verifier checks credential validity, credential status, issuer-key status, and rotation history.
+- **Stale/revoked credentials:** active keys may issue and verify. Retired keys cannot issue and may verify only credentials issued inside their authorization interval and before retirement. Revoked keys always fail. Lifecycle timestamps keep rotation history explicit and serializable.
 - **Verifier collusion:** audience-bound presentations cannot be replayed to a second audience; policy and legal controls are still needed because a verifier can copy information it legitimately sees.
 - **Misleading clearance claims:** UI/output must use the exact label “Cryptographically verified employer attestation — not a security clearance or government endorsement.”
-- **Forged résumé evidence:** the issuer can bind a salted commitment to an exact frozen packet assertion; altered text does not match.
+- **Forged résumé evidence:** the verifier must supply the exact frozen assertion text and salt, recompute the commitment, and compare it in constant time. A digest-shaped value alone is never accepted as evidence.
 
 ## Synthetic-only boundary
 

--- a/lib/sensitive-attestation.test.ts
+++ b/lib/sensitive-attestation.test.ts
@@ -1,43 +1,109 @@
 import { describe, expect, it } from "vitest";
-import { assertionCommitment, createSensitivePresentation, generateAttestationKeyPair, issueSensitiveCredential, SensitiveClaimSchema, verifySensitivePresentation, type CredentialStatus, type TrustRegistry } from "./sensitive-attestation";
+import {
+  APPROVED_ASSURANCE_CATEGORIES,
+  InMemoryNonceStore,
+  SensitiveClaimSchema,
+  assertionCommitment,
+  createSensitivePresentation,
+  generateAttestationKeyPair,
+  issueSensitiveCredential,
+  verifySensitivePresentation,
+  type CredentialStatus,
+  type IssuerKey,
+  type SensitivePresentation,
+  type TrustRegistry,
+} from "./sensitive-attestation";
 
-const issuer = generateAttestationKeyPair(); const holder = generateAttestationKeyPair();
-const registry: TrustRegistry = { issuers: [{ issuerId: "synthetic-employer", keyId: "2026-a", publicKey: issuer.publicKey, allowedClaims: ["sensitiveWorkParticipation", "attestationScope", "subjectBinding", "assertionCommitment"], validFrom: "2025-01-01T00:00:00Z", validUntil: "2030-01-01T00:00:00Z", status: "active" }] };
+const issuer = generateAttestationKeyPair();
+const otherIssuer = generateAttestationKeyPair();
+const holder = generateAttestationKeyPair();
+const activeKey: IssuerKey = {
+  issuerId: "synthetic-employer", keyId: "2026-a", publicKey: issuer.publicKey,
+  allowedClaims: ["sensitiveWorkParticipation", "attestationScope", "subjectBinding", "assertionCommitment", "assuranceCategory"],
+  validFrom: "2025-01-01T00:00:00Z", validUntil: "2030-01-01T00:00:00Z", status: "active",
+};
+const registry: TrustRegistry = { issuers: [activeKey] };
 const status: CredentialStatus = { revokedCredentialIds: new Set() };
-const claim = { sensitiveWorkParticipation: true as const, attestationScope: "accomplishment" as const, subjectBinding: "a".repeat(64), assertionCommitment: assertionCommitment("Led an approved sensitive-work effort", "packet-salt") };
-function credential() { return issueSensitiveCredential({ claim, issuerId: "synthetic-employer", keyId: "2026-a", issuerPrivateKey: issuer.privateKey, holderPublicKey: holder.publicKey, validFrom: new Date("2026-01-01"), validUntil: new Date("2028-01-01") }); }
-function presentation(credential_ = credential(), nonce = "verifier-nonce") { return createSensitivePresentation({ credential: credential_, disclose: ["sensitiveWorkParticipation", "attestationScope", "assertionCommitment"], holderPrivateKey: holder.privateKey, audience: "prospective-employer", nonce, expiresAt: new Date("2026-06-01T00:05:00Z") }); }
-function verifyOne(presentation_ = presentation(), overrides: Partial<Parameters<typeof verifySensitivePresentation>[0]> = {}) { const used = new Set<string>(); return verifySensitivePresentation({ presentation: presentation_, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), consumeNonce: (nonce) => { if (used.has(nonce)) return false; used.add(nonce); return true; }, requiredClaims: ["sensitiveWorkParticipation"], ...overrides }); }
+const frozenAssertion = { text: "Led an approved sensitive-work effort", salt: "packet-salt" };
+const claim = {
+  sensitiveWorkParticipation: true as const,
+  assuranceCategory: APPROVED_ASSURANCE_CATEGORIES[0],
+  attestationScope: "accomplishment" as const,
+  subjectBinding: "a".repeat(64),
+  assertionCommitment: assertionCommitment(frozenAssertion.text, frozenAssertion.salt),
+};
+function credential(key = activeKey, privateKey = issuer.privateKey) {
+  return issueSensitiveCredential({ claim, issuerKey: key, issuerPrivateKey: privateKey, holderPublicKey: holder.publicKey, issuedAt: new Date("2026-01-01"), validFrom: new Date("2026-01-01"), validUntil: new Date("2028-01-01") });
+}
+function presentation(credential_ = credential(), nonce = "verifier-nonce") {
+  return createSensitivePresentation({ credential: credential_, disclose: ["sensitiveWorkParticipation", "attestationScope", "assertionCommitment", "assuranceCategory"], holderPrivateKey: holder.privateKey, audience: "prospective-employer", nonce, expiresAt: new Date("2026-06-01T00:05:00Z") });
+}
+function verifyOne(presentation_ = presentation(), overrides: Partial<Parameters<typeof verifySensitivePresentation>[0]> = {}) {
+  return verifySensitivePresentation({ presentation: presentation_, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), nonceStore: new InMemoryNonceStore(), frozenAssertion, requiredClaims: ["sensitiveWorkParticipation"], ...overrides });
+}
+function mutateSignature(value: string) {
+  const bytes = Buffer.from(value, "base64url");
+  bytes[0] ^= 1;
+  return bytes.toString("base64url");
+}
 
 describe("sensitive-work employer attestation", () => {
-  it("rejects forbidden or detailed fields at schema boundary", () => {
+  it("rejects forbidden fields and category-shaped covert channels", () => {
     for (const forbidden of ["programName", "customer", "contract", "clearanceLevel", "technology", "location", "duties"]) expect(() => SensitiveClaimSchema.parse({ ...claim, [forbidden]: "SECRET" })).toThrow();
+    for (const encoded of ["CUSTOMER_X", "TS_SCI", "PROGRAM-ALPHA", "AWS-CLOUD", "RF-AC-999"]) expect(() => SensitiveClaimSchema.parse({ ...claim, assuranceCategory: encoded })).toThrow();
   });
+
   it("selectively discloses approved predicates without hidden subject binding", () => {
     const shown = presentation(); const result = verifyOne(shown);
     expect(result.valid).toBe(true); expect(result.claims).not.toHaveProperty("subjectBinding");
     expect(JSON.stringify(shown)).not.toContain(claim.subjectBinding); expect(result.label).toContain("not a security clearance");
   });
-  it("binds presentations to holder, audience, nonce, and expiry", () => {
+
+  it("binds presentations to holder, audience, nonce, and expiry with deterministic tampering", () => {
     expect(() => verifyOne(presentation(), { expectedAudience: "attacker" })).toThrow(/audience/);
     expect(() => verifyOne(presentation(), { expectedNonce: "other" })).toThrow(/nonce/);
     expect(() => verifyOne(presentation(), { now: new Date("2026-06-01T00:06:00Z") })).toThrow(/expired/);
-    const tampered = presentation(); tampered.holderSignature = `${tampered.holderSignature.slice(0, -2)}AA`; expect(() => verifyOne(tampered)).toThrow(/Holder/);
+    const tampered = presentation(); tampered.holderSignature = mutateSignature(tampered.holderSignature);
+    expect(() => verifyOne(tampered)).toThrow(/Holder/);
   });
-  it("rejects replay through verifier nonce consumption", () => {
-    const shown = presentation(); const used = new Set<string>(); const consumeNonce = (nonce: string) => { if (used.has(nonce)) return false; used.add(nonce); return true; };
-    const base = { presentation: shown, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), consumeNonce };
+
+  it("does not burn a nonce for wrong-key, altered-body, or invalid holder proofs", () => {
+    const nonceStore = new InMemoryNonceStore();
+    const valid = presentation();
+    const wrongKeyRegistry: TrustRegistry = { issuers: [{ ...activeKey, publicKey: otherIssuer.publicKey }] };
+    expect(() => verifyOne(valid, { registry: wrongKeyRegistry, nonceStore })).toThrow(/Issuer signature/);
+
+    const altered = structuredClone(valid) as SensitivePresentation;
+    altered.credential.validUntil = "2029-01-01T00:00:00.000Z";
+    expect(() => verifyOne(altered, { nonceStore })).toThrow(/Issuer signature/);
+
+    const badHolder = structuredClone(valid) as SensitivePresentation;
+    badHolder.holderSignature = mutateSignature(badHolder.holderSignature);
+    expect(() => verifyOne(badHolder, { nonceStore })).toThrow(/Holder/);
+    expect(verifyOne(valid, { nonceStore }).valid).toBe(true);
+  });
+
+  it("atomically rejects replay after a valid presentation", () => {
+    const shown = presentation(); const nonceStore = new InMemoryNonceStore();
+    const base = { presentation: shown, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), nonceStore, frozenAssertion };
     expect(verifySensitivePresentation(base).valid).toBe(true); expect(() => verifySensitivePresentation(base)).toThrow(/already consumed/);
   });
-  it("enforces issuer authorization, revocation, and key rotation", () => {
-    const shown = presentation(); const restricted: TrustRegistry = { issuers: [{ ...registry.issuers[0], allowedClaims: ["sensitiveWorkParticipation"] }] };
-    expect(() => verifyOne(shown, { registry: restricted })).toThrow(/not authorized/);
+
+  it("enforces issuer authorization, revocation, and rotation history", () => {
+    const shown = presentation();
+    expect(() => verifyOne(shown, { registry: { issuers: [{ ...activeKey, allowedClaims: ["sensitiveWorkParticipation"] }] } })).toThrow(/not authorized/);
     expect(() => verifyOne(shown, { status: { revokedCredentialIds: new Set([shown.credential.id]) } })).toThrow(/revoked/);
-    expect(() => verifyOne(shown, { registry: { issuers: [{ ...registry.issuers[0], status: "revoked" }] } })).toThrow(/not trusted/);
-    expect(verifyOne(shown, { registry: { issuers: [{ ...registry.issuers[0], status: "retired" }] } }).valid).toBe(true);
+    expect(() => verifyOne(shown, { registry: { issuers: [{ ...activeKey, status: "revoked", revokedAt: "2026-05-01T00:00:00Z" }] } })).toThrow(/not trusted/);
+    expect(verifyOne(shown, { registry: { issuers: [{ ...activeKey, status: "retired", retiredAt: "2026-02-01T00:00:00Z" }] } }).valid).toBe(true);
+    expect(() => verifyOne(shown, { registry: { issuers: [{ ...activeKey, status: "retired", retiredAt: "2025-12-01T00:00:00Z" }] } })).toThrow(/not trusted/);
+    const retiredKey = { ...activeKey, status: "retired" as const, retiredAt: "2026-02-01T00:00:00Z" };
+    expect(() => credential(retiredKey)).toThrow(/Only an active/);
   });
-  it("verifies a salted commitment to the exact frozen resume assertion", () => {
-    const result = verifyOne(); expect(result.claims.assertionCommitment).toBe(assertionCommitment("Led an approved sensitive-work effort", "packet-salt"));
-    expect(result.claims.assertionCommitment).not.toBe(assertionCommitment("Changed assertion", "packet-salt"));
+
+  it("recomputes the commitment from the exact frozen assertion and salt", () => {
+    expect(verifyOne().claims.assertionCommitment).toBe(claim.assertionCommitment);
+    expect(() => verifyOne(presentation(), { frozenAssertion: { text: "Changed assertion", salt: frozenAssertion.salt } })).toThrow(/commitment/);
+    expect(() => verifyOne(presentation(), { frozenAssertion: { text: frozenAssertion.text, salt: "wrong-salt" } })).toThrow(/commitment/);
+    expect(() => verifyOne(presentation(), { frozenAssertion: undefined })).toThrow(/text and salt/);
   });
 });

--- a/lib/sensitive-attestation.ts
+++ b/lib/sensitive-attestation.ts
@@ -1,38 +1,135 @@
-import { createHash, generateKeyPairSync, randomBytes, randomUUID, sign, verify } from "node:crypto";
+import { createHash, generateKeyPairSync, randomBytes, randomUUID, sign, timingSafeEqual, verify } from "node:crypto";
 import { z } from "zod";
+
+/**
+ * Opaque, issuer-approved vocabulary. The values intentionally carry no
+ * program, customer, contract, clearance, technology, location, or duty data.
+ * Adding a value requires governance review; callers cannot mint new values.
+ */
+export const APPROVED_ASSURANCE_CATEGORIES = ["RF-AC-001", "RF-AC-002", "RF-AC-003"] as const;
+export const AssuranceCategorySchema = z.enum(APPROVED_ASSURANCE_CATEGORIES);
 
 export const SensitiveClaimSchema = z.strictObject({
   sensitiveWorkParticipation: z.literal(true),
-  assuranceCategory: z.string().regex(/^[A-Z0-9_-]{1,32}$/).optional(),
+  assuranceCategory: AssuranceCategorySchema.optional(),
   timeRange: z.string().regex(/^\d{4}(?:-\d{4})?$/).optional(),
   attestationScope: z.enum(["employment", "accomplishment", "role-family"]),
   subjectBinding: z.string().regex(/^[a-f0-9]{64}$/),
   assertionCommitment: z.string().regex(/^[a-f0-9]{64}$/).optional(),
 });
 export type SensitiveClaim = z.infer<typeof SensitiveClaimSchema>;
-type ClaimKey = keyof SensitiveClaim;
-export type IssuerKey = { issuerId: string; keyId: string; publicKey: string; allowedClaims: ClaimKey[]; validFrom: string; validUntil: string; status: "active" | "retired" | "revoked" };
+export type ClaimKey = keyof SensitiveClaim;
+
+type KeyLifecycle =
+  | { status: "active"; retiredAt?: never; revokedAt?: never }
+  | { status: "retired"; retiredAt: string; revokedAt?: never }
+  | { status: "revoked"; revokedAt: string; retiredAt?: string };
+export type IssuerKey = {
+  issuerId: string;
+  keyId: string;
+  publicKey: string;
+  allowedClaims: ClaimKey[];
+  validFrom: string;
+  validUntil: string;
+} & KeyLifecycle;
 export type TrustRegistry = { issuers: IssuerKey[] };
 type Disclosure = [salt: string, key: ClaimKey, value: unknown];
-export type SensitiveCredential = { profile: "RF-SENSITIVE-SD-1"; id: string; issuerId: string; keyId: string; validFrom: string; validUntil: string; holderPublicKey: string; digests: string[]; signature: string; disclosures: Disclosure[] };
-export type SensitivePresentation = { credential: Omit<SensitiveCredential, "disclosures">; disclosures: Disclosure[]; audience: string; nonce: string; expiresAt: string; holderSignature: string };
+export type SensitiveCredential = {
+  profile: "RF-SENSITIVE-SD-1";
+  id: string;
+  issuerId: string;
+  keyId: string;
+  issuedAt: string;
+  validFrom: string;
+  validUntil: string;
+  holderPublicKey: string;
+  digests: string[];
+  signature: string;
+  disclosures: Disclosure[];
+};
+export type SensitivePresentation = {
+  credential: Omit<SensitiveCredential, "disclosures">;
+  disclosures: Disclosure[];
+  audience: string;
+  nonce: string;
+  expiresAt: string;
+  holderSignature: string;
+};
 export type CredentialStatus = { revokedCredentialIds: Set<string> };
+export interface NonceStore {
+  /** Must atomically return false when the nonce was consumed previously. */
+  consume(nonce: string): boolean;
+}
+
+export class InMemoryNonceStore implements NonceStore {
+  private readonly consumed = new Set<string>();
+  consume(nonce: string) {
+    if (this.consumed.has(nonce)) return false;
+    this.consumed.add(nonce);
+    return true;
+  }
+}
 
 function canonical(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
-  if (value && typeof value === "object") { const record = value as Record<string, unknown>; return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`; }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`;
+  }
   return JSON.stringify(value);
 }
 const digest = (value: unknown) => createHash("sha256").update(canonical(value)).digest("hex");
-export function assertionCommitment(assertion: string, salt: string) { return digest({ assertion: assertion.normalize("NFKC").trim(), salt }); }
-export function generateAttestationKeyPair() { return generateKeyPairSync("ed25519", { publicKeyEncoding: { type: "spki", format: "pem" }, privateKeyEncoding: { type: "pkcs8", format: "pem" } }); }
+export function assertionCommitment(assertion: string, salt: string) {
+  if (!salt) throw new Error("Assertion commitment salt is required.");
+  return digest({ assertion: assertion.normalize("NFKC").trim(), salt });
+}
+export function generateAttestationKeyPair() {
+  return generateKeyPairSync("ed25519", { publicKeyEncoding: { type: "spki", format: "pem" }, privateKeyEncoding: { type: "pkcs8", format: "pem" } });
+}
 
-export function issueSensitiveCredential(input: { claim: SensitiveClaim; issuerId: string; keyId: string; issuerPrivateKey: string; holderPublicKey: string; validFrom: Date; validUntil: Date }): SensitiveCredential {
-  const claim = SensitiveClaimSchema.parse(input.claim); if (input.validUntil <= input.validFrom) throw new Error("Credential validity window is invalid.");
+function parseDate(value: string, label: string) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) throw new Error(`${label} is invalid.`);
+  return date;
+}
+
+function signatureBytes(value: string, label: string) {
+  if (!/^[A-Za-z0-9_-]{86}$/.test(value)) throw new Error(`${label} is invalid.`);
+  const bytes = Buffer.from(value, "base64url");
+  if (bytes.length !== 64 || bytes.toString("base64url") !== value) throw new Error(`${label} is invalid.`);
+  return bytes;
+}
+
+function keyCanIssue(key: IssuerKey, issuedAt: Date) {
+  return key.status === "active"
+    && parseDate(key.validFrom, "Issuer key validFrom") <= issuedAt
+    && issuedAt < parseDate(key.validUntil, "Issuer key validUntil");
+}
+
+export function issueSensitiveCredential(input: {
+  claim: SensitiveClaim;
+  issuerKey: IssuerKey;
+  issuerPrivateKey: string;
+  holderPublicKey: string;
+  issuedAt: Date;
+  validFrom: Date;
+  validUntil: Date;
+}): SensitiveCredential {
+  const claim = SensitiveClaimSchema.parse(input.claim);
+  if (!keyCanIssue(input.issuerKey, input.issuedAt)) throw new Error("Only an active issuer key may issue a credential within its authorization interval.");
+  if (input.validUntil <= input.validFrom || input.validFrom < input.issuedAt) throw new Error("Credential validity window is invalid.");
   const disclosures = Object.entries(claim).map(([key, value]) => [randomBytes(16).toString("base64url"), key as ClaimKey, value] satisfies Disclosure);
-  const unsigned = { profile: "RF-SENSITIVE-SD-1" as const, id: randomUUID(), issuerId: input.issuerId, keyId: input.keyId,
-    validFrom: input.validFrom.toISOString(), validUntil: input.validUntil.toISOString(), holderPublicKey: input.holderPublicKey,
-    digests: disclosures.map(digest).sort() };
+  const unsigned = {
+    profile: "RF-SENSITIVE-SD-1" as const,
+    id: randomUUID(),
+    issuerId: input.issuerKey.issuerId,
+    keyId: input.issuerKey.keyId,
+    issuedAt: input.issuedAt.toISOString(),
+    validFrom: input.validFrom.toISOString(),
+    validUntil: input.validUntil.toISOString(),
+    holderPublicKey: input.holderPublicKey,
+    digests: disclosures.map(digest).sort(),
+  };
   return { ...unsigned, signature: sign(null, Buffer.from(canonical(unsigned)), input.issuerPrivateKey).toString("base64url"), disclosures };
 }
 
@@ -44,25 +141,66 @@ export function createSensitivePresentation(input: { credential: SensitiveCreden
   return { credential, disclosures, audience: input.audience, nonce: input.nonce, expiresAt: input.expiresAt.toISOString(), holderSignature: sign(null, Buffer.from(canonical(proof)), input.holderPrivateKey).toString("base64url") };
 }
 
-export function verifySensitivePresentation(input: { presentation: SensitivePresentation; registry: TrustRegistry; status: CredentialStatus; expectedAudience: string; expectedNonce: string; now?: Date; consumeNonce: (nonce: string) => boolean; requiredClaims?: ClaimKey[] }) {
-  const now = input.now ?? new Date(); const presentation = input.presentation; const credential = presentation.credential;
-  if (presentation.audience !== input.expectedAudience || presentation.nonce !== input.expectedNonce) throw new Error("Presentation audience or nonce mismatch.");
-  if (new Date(presentation.expiresAt) <= now) throw new Error("Presentation expired.");
-  if (!input.consumeNonce(presentation.nonce)) throw new Error("Presentation nonce was already consumed.");
-  if (input.status.revokedCredentialIds.has(credential.id)) throw new Error("Credential is revoked.");
-  if (new Date(credential.validFrom) > now || new Date(credential.validUntil) <= now) throw new Error("Credential is outside its validity window.");
+function keyCanVerifyCredential(key: IssuerKey, issuedAt: Date) {
+  const withinAuthorization = parseDate(key.validFrom, "Issuer key validFrom") <= issuedAt && issuedAt < parseDate(key.validUntil, "Issuer key validUntil");
+  if (!withinAuthorization || key.status === "revoked") return false;
+  if (key.status === "retired") return issuedAt < parseDate(key.retiredAt, "Issuer key retiredAt");
+  return true;
+}
+
+export function verifySensitivePresentation(input: {
+  presentation: SensitivePresentation;
+  registry: TrustRegistry;
+  status: CredentialStatus;
+  expectedAudience: string;
+  expectedNonce: string;
+  nonceStore: NonceStore;
+  frozenAssertion?: { text: string; salt: string };
+  now?: Date;
+  requiredClaims?: ClaimKey[];
+}) {
+  const now = input.now ?? new Date();
+  const presentation = input.presentation;
+  const credential = presentation.credential;
+
+  // Authenticate the issuer and holder before consulting or mutating replay state.
+  if (credential.profile !== "RF-SENSITIVE-SD-1") throw new Error("Credential profile is invalid.");
+  const issuedAt = parseDate(credential.issuedAt, "Credential issuedAt");
   const key = input.registry.issuers.find((entry) => entry.issuerId === credential.issuerId && entry.keyId === credential.keyId);
-  if (!key || key.status === "revoked" || new Date(key.validFrom) > now || new Date(key.validUntil) <= now) throw new Error("Issuer key is not trusted for this time and scope.");
+  if (!key || !keyCanVerifyCredential(key, issuedAt)) throw new Error("Issuer key is not trusted for this credential issuance.");
   const { signature, ...unsigned } = credential;
-  if (!verify(null, Buffer.from(canonical(unsigned)), key.publicKey, Buffer.from(signature, "base64url"))) throw new Error("Issuer signature is invalid.");
+  if (!verify(null, Buffer.from(canonical(unsigned)), key.publicKey, signatureBytes(signature, "Issuer signature"))) throw new Error("Issuer signature is invalid.");
+
+  const proof = { credentialId: credential.id, disclosureDigests: presentation.disclosures.map(digest).sort(), audience: presentation.audience, nonce: presentation.nonce, expiresAt: presentation.expiresAt };
+  if (!verify(null, Buffer.from(canonical(proof)), credential.holderPublicKey, signatureBytes(presentation.holderSignature, "Holder signature"))) throw new Error("Holder binding proof is invalid.");
+
+  if (presentation.audience !== input.expectedAudience || presentation.nonce !== input.expectedNonce) throw new Error("Presentation audience or nonce mismatch.");
+  if (parseDate(presentation.expiresAt, "Presentation expiresAt") <= now) throw new Error("Presentation expired.");
+  if (input.status.revokedCredentialIds.has(credential.id)) throw new Error("Credential is revoked.");
+  if (parseDate(credential.validFrom, "Credential validFrom") > now || parseDate(credential.validUntil, "Credential validUntil") <= now) throw new Error("Credential is outside its validity window.");
+
   for (const disclosure of presentation.disclosures) {
     if (!credential.digests.includes(digest(disclosure))) throw new Error("Disclosure is not bound to the credential.");
     if (!key.allowedClaims.includes(disclosure[1])) throw new Error(`Issuer is not authorized for ${disclosure[1]}.`);
   }
-  const claims = Object.fromEntries(presentation.disclosures.map(([, name, value]) => [name, value])); SensitiveClaimSchema.partial().parse(claims);
+  const claims = Object.fromEntries(presentation.disclosures.map(([, name, value]) => [name, value]));
+  SensitiveClaimSchema.partial().parse(claims);
   for (const required of input.requiredClaims ?? []) if (!(required in claims)) throw new Error(`Required claim ${required} was not disclosed.`);
-  const proof = { credentialId: credential.id, disclosureDigests: presentation.disclosures.map(digest).sort(), audience: presentation.audience, nonce: presentation.nonce, expiresAt: presentation.expiresAt };
-  if (!verify(null, Buffer.from(canonical(proof)), credential.holderPublicKey, Buffer.from(presentation.holderSignature, "base64url"))) throw new Error("Holder binding proof is invalid.");
-  return { valid: true as const, credentialId: credential.id, issuerId: credential.issuerId, claims,
-    label: "Cryptographically verified employer attestation — not a security clearance or government endorsement" };
+
+  if (claims.assertionCommitment !== undefined) {
+    if (!input.frozenAssertion) throw new Error("Frozen assertion text and salt are required to verify its commitment.");
+    const expected = Buffer.from(assertionCommitment(input.frozenAssertion.text, input.frozenAssertion.salt), "hex");
+    const actual = Buffer.from(String(claims.assertionCommitment), "hex");
+    if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) throw new Error("Frozen assertion commitment does not match.");
+  }
+
+  // Last step: only a fully authenticated, policy-valid presentation burns a nonce.
+  if (!input.nonceStore.consume(presentation.nonce)) throw new Error("Presentation nonce was already consumed.");
+  return {
+    valid: true as const,
+    credentialId: credential.id,
+    issuerId: credential.issuerId,
+    claims,
+    label: "Cryptographically verified employer attestation — not a security clearance or government endorsement",
+  };
 }


### PR DESCRIPTION
## Summary
- replace free-form assurance categories with an approved opaque vocabulary
- authenticate issuer and holder, validate policy and frozen assertion commitments, then consume replay nonces last
- enforce active/retired/revoked issuer-key lifecycle with issuance history
- make signature tampering deterministic and prove invalid presentations cannot burn a valid nonce

## Validation
- npm test (117/117)
- npm run lint
- npm run typecheck
- npm run build
- npm audit --audit-level=high (0 vulnerabilities)
- node scripts/generate-agent-openapi.mjs (no diff)

## Boundary
RF-SENSITIVE-SD-1 remains explicitly synthetic and not externally interoperable. A production deployment must inject a durable shared nonce store; this branch defines the atomic interface and a test/local-process implementation only.