### PR TITLE
Verify packet integrity and close UI boundaries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -504,26 +504,34 @@ export default function Home() {
                 }}
               />
             </div>
+            <label htmlFor="job-description" className="sr-only">Job description</label>
             <textarea
+              id="job-description"
               value={jobText}
               onChange={(e) => { invalidateResult(); setJobText(e.target.value); }}
               placeholder="…or paste the full job description here…"
               className="h-40 w-full resize-y rounded-lg border border-ink-700 bg-ink-950/80 p-3 font-mono text-xs leading-relaxed text-ink-100 outline-none transition focus:border-brass-400/60"
             />
             <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              <label htmlFor="job-title" className="sr-only">Job title (optional)</label>
               <input
+                id="job-title"
                 value={jobTitle}
                 onChange={(e) => { invalidateResult(); setJobTitle(e.target.value); }}
                 placeholder="Job title (optional)"
                 className="rounded-lg border border-ink-700 bg-ink-950/80 px-3 py-2 text-xs text-ink-100 outline-none transition focus:border-brass-400/60"
               />
+              <label htmlFor="job-company" className="sr-only">Company (optional)</label>
               <input
+                id="job-company"
                 value={company}
                 onChange={(e) => { invalidateResult(); setCompany(e.target.value); }}
                 placeholder="Company (optional)"
                 className="rounded-lg border border-ink-700 bg-ink-950/80 px-3 py-2 text-xs text-ink-100 outline-none transition focus:border-brass-400/60"
               />
+              <label htmlFor="tailoring-emphasis" className="sr-only">Tailoring emphasis</label>
               <select
+                id="tailoring-emphasis"
                 value={emphasis}
                 onChange={(e) => { invalidateResult(); setEmphasis(e.target.value as typeof emphasis); }}
                 className="rounded-lg border border-ink-700 bg-ink-950/80 px-3 py-2 text-xs text-ink-100 outline-none transition focus:border-brass-400/60"

--- a/lib/applications.test.ts
+++ b/lib/applications.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applicationAnalytics, approveReminder, buildInterviewPrep, createApplicationPacket, createApplicationRecord, dismissReminder, transitionApplication } from "./applications";
+import { applicationAnalytics, approveReminder, buildInterviewPrep, createApplicationPacket, createApplicationRecord, dismissReminder, transitionApplication, verifyApplicationPacket } from "./applications";
 import { createJobSnapshot } from "./job-inbox";
 import type { TailorResult } from "./schema";
 
@@ -15,6 +15,13 @@ describe("immutable application packets", () => {
     const created = await packet(); const old = created.tailoredResult.tailored_resume_markdown;
     result.tailored_resume_markdown = "Changed later";
     expect(created.checksums.packet).toMatch(/^[a-f0-9]{64}$/); expect(created.checksums.resume).toMatch(/^[a-f0-9]{64}$/); expect(created.tailoredResult.tailored_resume_markdown).toBe(old);
+  });
+  it("re-verifies every immutable artifact and rejects a rehydrated tampered packet", async () => {
+    const created = await packet();
+    expect(await verifyApplicationPacket(created)).toEqual({ valid: true, errors: [] });
+    const tampered = structuredClone(created); tampered.tailoredResult.tailored_resume_markdown = "# Unapproved replacement";
+    expect(await verifyApplicationPacket(tampered)).toMatchObject({ valid: false });
+    await expect(transitionApplication(createApplicationRecord(tampered), "submitted")).rejects.toThrow(/integrity failed/);
   });
   it("allows only valid state transitions and records submission time", async () => {
     const record = createApplicationRecord(await packet());

--- a/lib/applications.ts
+++ b/lib/applications.ts
@@ -91,6 +91,24 @@ export async function createApplicationPacket(input: {
   return structuredClone({ ...partial, checksums });
 }
 
+export async function verifyApplicationPacket(packet: ApplicationPacket): Promise<{ valid: boolean; errors: string[] }> {
+  const errors: string[] = [];
+  const profile = { resume: packet.profileSnapshot.resume, extraInfo: packet.profileSnapshot.extraInfo };
+  const expected = {
+    job: await sha256(canonical(packet.jobSnapshot)),
+    profile: await sha256(canonical(profile)),
+    resume: await sha256(packet.tailoredResult.tailored_resume_markdown),
+    coverLetter: await sha256(packet.tailoredResult.cover_letter_markdown),
+  };
+  if (packet.profileSnapshot.checksum !== expected.profile) errors.push("Profile snapshot checksum mismatch.");
+  for (const key of ["job", "profile", "resume", "coverLetter"] as const) {
+    if (packet.checksums[key] !== expected[key]) errors.push(`${key} checksum mismatch.`);
+  }
+  const { checksums: _checksums, ...body } = packet;
+  if (packet.checksums.packet !== await sha256(canonical(body))) errors.push("Packet checksum mismatch.");
+  return { valid: errors.length === 0, errors };
+}
+
 export function createApplicationRecord(packet: ApplicationPacket): ApplicationRecord {
   return { id: crypto.randomUUID(), packet: structuredClone(packet), packetHistory: [], state: "ready", timeline: [{ at: packet.createdAt, type: "packet.created", detail: `Packet v${packet.version} created` }], notes: [], contacts: [], interviewDates: [], followUpAt: null, compensation: "", referral: "", rejectionReason: "", nextAction: "Review and approve submission", documentLinks: [], emailLinks: [], calendarLinks: [], reminders: [] };
 }
@@ -136,6 +154,8 @@ export function buildInterviewPrep(record: ApplicationRecord) {
 export function allowedTransitions(state: ApplicationState): readonly ApplicationState[] { return TRANSITIONS[state]; }
 
 export async function transitionApplication(record: ApplicationRecord, next: ApplicationState, now = new Date()): Promise<ApplicationRecord> {
+  const integrity = await verifyApplicationPacket(record.packet);
+  if (!integrity.valid) throw new Error(`Application packet integrity failed: ${integrity.errors.join(" ")}`);
   if (!TRANSITIONS[record.state].includes(next)) throw new Error(`Invalid application transition: ${record.state} -> ${next}`);
   const updated = structuredClone(record);
   updated.state = next;

--- a/lib/sensitive-attestation.test.ts
+++ b/lib/sensitive-attestation.test.ts
@@ -83,6 +83,15 @@ describe("sensitive-work employer attestation", () => {
     expect(verifyOne(valid, { nonceStore }).valid).toBe(true);
   });
 
+  it("rejects duplicate disclosed claim keys before consuming the nonce", () => {
+    const nonceStore = new InMemoryNonceStore();
+    const duplicatedCredential = credential();
+    duplicatedCredential.disclosures.push(duplicatedCredential.disclosures[0]);
+    const duplicated = presentation(duplicatedCredential);
+    expect(() => verifyOne(duplicated, { nonceStore })).toThrow(/more than once/);
+    expect(verifyOne(presentation(), { nonceStore }).valid).toBe(true);
+  });
+
   it("atomically rejects replay after a valid presentation", () => {
     const shown = presentation(); const nonceStore = new InMemoryNonceStore();
     const base = { presentation: shown, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), nonceStore, frozenAssertion };

--- a/lib/sensitive-attestation.ts
+++ b/lib/sensitive-attestation.ts
@@ -179,7 +179,10 @@ export function verifySensitivePresentation(input: {
   if (input.status.revokedCredentialIds.has(credential.id)) throw new Error("Credential is revoked.");
   if (parseDate(credential.validFrom, "Credential validFrom") > now || parseDate(credential.validUntil, "Credential validUntil") <= now) throw new Error("Credential is outside its validity window.");
 
+  const disclosedKeys = new Set<ClaimKey>();
   for (const disclosure of presentation.disclosures) {
+    if (disclosedKeys.has(disclosure[1])) throw new Error(`Claim ${disclosure[1]} was disclosed more than once.`);
+    disclosedKeys.add(disclosure[1]);
     if (!credential.digests.includes(digest(disclosure))) throw new Error("Disclosure is not bound to the credential.");
     if (!key.allowedClaims.includes(disclosure[1])) throw new Error(`Issuer is not authorized for ${disclosure[1]}.`);
   }


### PR DESCRIPTION
Adds re-verification of every application packet checksum and blocks transitions on rehydrated tampering; supplies durable accessible labels for job fields; incorporates independent PR38 cross-review fix rejecting duplicate disclosed claim keys before nonce consumption. Verification: 123/123 tests, lint, typecheck, production build, audit 0.