### PR TITLE
Reject duplicate attestation disclosure keys

### DIFF
--- a/lib/sensitive-attestation.test.ts
+++ b/lib/sensitive-attestation.test.ts
@@ -83,6 +83,15 @@ describe("sensitive-work employer attestation", () => {
     expect(verifyOne(valid, { nonceStore }).valid).toBe(true);
   });
 
+  it("rejects duplicate disclosed claim keys before consuming the nonce", () => {
+    const nonceStore = new InMemoryNonceStore();
+    const duplicatedCredential = credential();
+    duplicatedCredential.disclosures.push(duplicatedCredential.disclosures[0]);
+    const duplicated = presentation(duplicatedCredential);
+    expect(() => verifyOne(duplicated, { nonceStore })).toThrow(/more than once/);
+    expect(verifyOne(presentation(), { nonceStore }).valid).toBe(true);
+  });
+
   it("atomically rejects replay after a valid presentation", () => {
     const shown = presentation(); const nonceStore = new InMemoryNonceStore();
     const base = { presentation: shown, registry, status, expectedAudience: "prospective-employer", expectedNonce: "verifier-nonce", now: new Date("2026-06-01T00:00:00Z"), nonceStore, frozenAssertion };

--- a/lib/sensitive-attestation.ts
+++ b/lib/sensitive-attestation.ts
@@ -179,7 +179,10 @@ export function verifySensitivePresentation(input: {
   if (input.status.revokedCredentialIds.has(credential.id)) throw new Error("Credential is revoked.");
   if (parseDate(credential.validFrom, "Credential validFrom") > now || parseDate(credential.validUntil, "Credential validUntil") <= now) throw new Error("Credential is outside its validity window.");
 
+  const disclosedKeys = new Set<ClaimKey>();
   for (const disclosure of presentation.disclosures) {
+    if (disclosedKeys.has(disclosure[1])) throw new Error(`Claim ${disclosure[1]} was disclosed more than once.`);
+    disclosedKeys.add(disclosure[1]);
     if (!credential.digests.includes(digest(disclosure))) throw new Error("Disclosure is not bound to the credential.");
     if (!key.allowedClaims.includes(disclosure[1])) throw new Error(`Issuer is not authorized for ${disclosure[1]}.`);
   }


### PR DESCRIPTION
Follow-up to merged PR #38 after independent cross-review. Rejects duplicate disclosed claim keys before nonce consumption, preventing order-dependent last-wins claim semantics, and adds a regression proving the rejected presentation does not burn the valid nonce.

Validation: focused 8/8 and typecheck pass.