### PR TITLE
P0: bind submissions to approvals, close agent authorization gaps, fix MCP and model resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ RESUME_FOUNDRY_CONNECTION_KEY=
 
 # Agent HTTP/MCP policy and durable audit store
 RESUME_FOUNDRY_AGENT_API_TOKEN=
+# The stdio MCP surface has no transport authentication; its trust boundary is
+# the local user who launched it. Opt in explicitly.
+RESUME_FOUNDRY_MCP_ENABLED=false
 RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET=
 RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT=10
 # Required for agent operations; use an absolute path on durable storage.
@@ -19,4 +22,6 @@ RESUME_FOUNDRY_AGENT_STORE=C:\path\to\private\resume-foundry-agent-store.json
 RESUME_FOUNDRY_AUTHORIZED_SUBMISSION_PROVIDERS=greenhouse:employer-board,lever:employer-site,gmail:me
 GREENHOUSE_JOB_BOARD_API_KEY=
 LEVER_POSTINGS_API_KEY=
-RESUME_FOUNDRY_SUBMISSION_LEDGER=C:\path\to\private\resume-foundry-submission-ledger.json
+# Append-only JSONL record of consumed approvals. Single-use nonce markers go to
+# a sibling "<path>.nonces" directory on the same durable volume.
+RESUME_FOUNDRY_SUBMISSION_LEDGER=C:\path\to\private\resume-foundry-submission-ledger.jsonl

--- a/app/api/capabilities/route.ts
+++ b/app/api/capabilities/route.ts
@@ -21,13 +21,15 @@ export function GET() {
       { id: "tailorResume", method: "POST", path: "/api/tailor", openWorld: true, streaming: "ndjson" },
       { id: "agentOperations", method: "POST", path: "/api/agent/{operation}", authentication: "bearer", humanApproval: true },
       { id: "agentAudit", method: "GET", path: "/api/agent/audit", authentication: "bearer" },
-      { id: "mcpTools", transport: "stdio", command: "npm run mcp", humanApproval: true },
+      { id: "mcpTools", transport: "stdio", command: "npm run mcp", authentication: "none-local-process-boundary", requiresOptIn: "RESUME_FOUNDRY_MCP_ENABLED", operations: "subset-excludes-approval-and-pii" },
     ],
     limitations: [
       "No public authentication or multi-user isolation.",
       "No A2A task endpoint or public multi-tenant identity boundary.",
       "Browser-local profiles, save points, run history, and encrypted career evidence are not server-readable.",
       "Human review is required before using generated application materials.",
+      "The stdio MCP surface has no transport authentication; its trust boundary is the local user who launched it.",
+      "Approval-gated and PII-bearing operations are HTTP-only so a model cannot supply its own approval.",
     ],
   });
 }

--- a/app/api/submissions/execute/route.ts
+++ b/app/api/submissions/execute/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
     if (!packet?.checksums) throw new Error("The approved application packet must be presented for submission.");
     const integrity = await verifyApplicationPacket(packet);
     if (!integrity.valid) throw new Error(`Application packet failed integrity verification: ${integrity.errors.join(" ")}`);
-    assertApprovedPacket(preview, packet.checksums);
+    assertApprovedPacket(preview, packet);
     const use = { nonce: receipt.nonce, applicationId: preview.applicationId, provider, consumedAt: new Date().toISOString() };
 
     if (provider === "greenhouse") {

--- a/app/api/submissions/execute/route.ts
+++ b/app/api/submissions/execute/route.ts
@@ -1,33 +1,76 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createGmailDraft, submitGreenhouse, submitLever, verifySubmissionApproval, type ApprovalReceipt } from "@/lib/submission-connectors";
+import { ApprovalReceiptSchema, assertApprovedPacket, createGmailDraft, submitGreenhouse, submitLever, verifySubmissionApproval, type SubmissionPreview } from "@/lib/submission-connectors";
+import { verifyApplicationPacket, type ApplicationPacket } from "@/lib/applications";
 import { consumeSubmissionApproval } from "@/lib/submission-ledger";
 import { googleOAuthConfig, openConnection } from "@/lib/google-oauth";
 import type { StoredGoogleConnection } from "../../connections/google/callback/route";
 
 function authorized(provider: string, identity: string) {
-  return (process.env.RESUME_FOUNDRY_AUTHORIZED_SUBMISSION_PROVIDERS ?? "").split(",").map((item) => item.trim()).includes(`${provider}:${identity}`);
+  return (process.env.RESUME_FOUNDRY_AUTHORIZED_SUBMISSION_PROVIDERS ?? "")
+    .split(",").map((item) => item.trim()).filter(Boolean)
+    .includes(`${provider}:${identity}`);
 }
+
+/**
+ * The provider account comes from the signed target, never the request body.
+ * It previously came from `body.boardToken ?? body.site ?? "me"`, so a caller
+ * could aim an approved receipt at any other allowlisted account.
+ */
+function approvedIdentity(preview: SubmissionPreview) {
+  switch (preview.target.provider) {
+    case "greenhouse": return preview.target.boardToken;
+    case "lever": return preview.target.site;
+    case "gmail": return "me";
+  }
+}
+
 export async function POST(request: Request) {
   try {
-    const body = await request.json() as Record<string, unknown>; const receipt = body.receipt as ApprovalReceipt;
-    const secret = process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET; if (!secret) throw new Error("Human approval is not configured.");
-    const preview = verifySubmissionApproval(receipt, secret); const provider = preview.provider;
-    const identity = String(body.boardToken ?? body.site ?? "me"); if (!authorized(provider, identity)) throw new Error("Employer-side submission authorization is not configured for this provider account.");
+    const body = await request.json() as Record<string, unknown>;
+    const secret = process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET;
+    if (!secret) throw new Error("Human approval is not configured.");
+
+    // Everything transmitted downstream is read from this verified preview.
+    // The request body contributes nothing but the receipt itself.
+    const receipt = ApprovalReceiptSchema.parse(body.receipt);
+    const preview = verifySubmissionApproval(receipt, secret);
+    const provider = preview.provider;
+    if (!authorized(provider, approvedIdentity(preview))) {
+      throw new Error("Employer-side submission authorization is not configured for this provider account.");
+    }
+
+    // The exact frozen packet must be presented, must be internally consistent,
+    // and must be the one that was approved. Integrity is checked first so a
+    // packet cannot satisfy the binding using checksums of its own tampered
+    // content.
+    const packet = body.packet as ApplicationPacket | undefined;
+    if (!packet?.checksums) throw new Error("The approved application packet must be presented for submission.");
+    const integrity = await verifyApplicationPacket(packet);
+    if (!integrity.valid) throw new Error(`Application packet failed integrity verification: ${integrity.errors.join(" ")}`);
+    assertApprovedPacket(preview, packet.checksums);
+    const use = { nonce: receipt.nonce, applicationId: preview.applicationId, provider, consumedAt: new Date().toISOString() };
+
     if (provider === "greenhouse") {
-      const apiKey = process.env.GREENHOUSE_JOB_BOARD_API_KEY; if (!apiKey) throw new Error("Greenhouse credential is unavailable.");
-      await consumeSubmissionApproval({ nonce: receipt.nonce, applicationId: preview.applicationId, provider, consumedAt: new Date().toISOString() });
-      return NextResponse.json(await submitGreenhouse({ boardToken: identity, jobId: String(body.jobId), apiKey, fields: body.fields as Record<string, unknown>, receipt, approvalSecret: secret }));
+      const apiKey = process.env.GREENHOUSE_JOB_BOARD_API_KEY;
+      if (!apiKey) throw new Error("Greenhouse credential is unavailable.");
+      await consumeSubmissionApproval(use);
+      return NextResponse.json(await submitGreenhouse({ apiKey, receipt, approvalSecret: secret }));
     }
     if (provider === "lever") {
-      const apiKey = process.env.LEVER_POSTINGS_API_KEY; if (!apiKey) throw new Error("Lever credential is unavailable.");
-      await consumeSubmissionApproval({ nonce: receipt.nonce, applicationId: preview.applicationId, provider, consumedAt: new Date().toISOString() });
-      return NextResponse.json(await submitLever({ site: identity, postingId: String(body.postingId), apiKey, requiredFields: body.requiredFields as string[], fields: body.fields as Record<string, unknown>, receipt, approvalSecret: secret }));
+      const apiKey = process.env.LEVER_POSTINGS_API_KEY;
+      if (!apiKey) throw new Error("Lever credential is unavailable.");
+      await consumeSubmissionApproval(use);
+      return NextResponse.json(await submitLever({ apiKey, receipt, approvalSecret: secret }));
     }
-    const sealed = (await cookies()).get("rf_google_connection")?.value; if (!sealed) throw new Error("Google OAuth connection is required.");
+
+    const sealed = (await cookies()).get("rf_google_connection")?.value;
+    if (!sealed) throw new Error("Google OAuth connection is required.");
     const connection = openConnection<StoredGoogleConnection>(sealed, googleOAuthConfig().encryptionKey);
     if (!connection.features.includes("email_drafts")) throw new Error("Gmail draft permission was not granted.");
-    await consumeSubmissionApproval({ nonce: receipt.nonce, applicationId: preview.applicationId, provider, consumedAt: new Date().toISOString() });
-    return NextResponse.json(await createGmailDraft({ accessToken: connection.tokens.access_token, rawMessage: String(body.rawMessage), receipt, approvalSecret: secret }));
-  } catch (error) { return NextResponse.json({ error: error instanceof Error ? error.message : "Submission failed." }, { status: 403 }); }
+    await consumeSubmissionApproval(use);
+    return NextResponse.json(await createGmailDraft({ accessToken: connection.tokens.access_token, receipt, approvalSecret: secret }));
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Submission failed." }, { status: 403 });
+  }
 }

--- a/app/api/tailor/route.ts
+++ b/app/api/tailor/route.ts
@@ -3,16 +3,11 @@ import { NextRequest } from "next/server";
 import { z } from "zod";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/prompts";
 import { assertTailorResultEvidence, HonestyValidationError, TailorRequestSchema, TailorResultSchema, tailorResultJsonSchema } from "@/lib/schema";
+import { resolveModel } from "@/lib/anthropic-model";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
-// Use an app-specific override first so unrelated shell/CLI aliases such as
-// ANTHROPIC_MODEL=opusplan cannot silently break this production route.
-const MODEL =
-  process.env.RESUME_FOUNDRY_ANTHROPIC_MODEL ||
-  process.env.ANTHROPIC_MODEL ||
-  "claude-opus-5";
 
 type StreamEvent =
   | { type: "thinking"; text: string }
@@ -49,7 +44,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
       try {
         const msgStream = client.beta.messages.stream({
-          model: MODEL,
+          model: resolveModel(),
           max_tokens: 64000,
           betas: ["server-side-fallback-2026-07-01"],
           fallbacks: "default",

--- a/lib/agent-contract.test.ts
+++ b/lib/agent-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import spec from "../public/openapi.json";
 import { AGENT_OPERATIONS } from "./agent-service";
+import { MCP_OPERATIONS } from "../scripts/mcp-server";
 
 describe("agent API and MCP contract parity", () => {
   it("publishes every policy operation in OpenAPI", () => {
@@ -8,9 +9,23 @@ describe("agent API and MCP contract parity", () => {
     for (const operation of AGENT_OPERATIONS) expect(paths[`/api/agent/${operation}`]).toBeDefined();
     expect(paths["/api/agent/audit"]).toBeDefined();
   });
-  it("registers every same operation in the MCP server source", async () => {
-    const source = await import("node:fs/promises").then(({ readFile }) => readFile(new URL("../scripts/mcp-server.ts", import.meta.url), "utf8"));
-    expect(source).toContain("for (const operation of AGENT_OPERATIONS)");
-    expect(source).toContain("executeAgentOperation({ operation");
+
+  it("publishes nothing under /api/agent that the policy service cannot execute", () => {
+    // The generator works from a hardcoded list and never prunes, so an
+    // operation could be advertised in OpenAPI while returning 404 in practice.
+    // The previous test only checked the code -> spec direction.
+    const advertised = Object.keys(spec.paths as Record<string, unknown>)
+      .filter((route) => route.startsWith("/api/agent/"))
+      .map((route) => route.replace("/api/agent/", ""))
+      .filter((operation) => operation !== "audit");
+    expect(advertised.sort()).toEqual([...AGENT_OPERATIONS].sort());
+  });
+
+  it("exposes a subset of the policy operations over stdio, and nothing beyond them", () => {
+    // Behavioural rather than a source grep: the previous test asserted that
+    // mcp-server.ts contained a particular line of source text, which would
+    // have passed unchanged even if the policy boundary were bypassed entirely.
+    expect(MCP_OPERATIONS.every((operation) => AGENT_OPERATIONS.includes(operation))).toBe(true);
+    expect(MCP_OPERATIONS.length).toBeLessThan(AGENT_OPERATIONS.length);
   });
 });

--- a/lib/agent-service.test.ts
+++ b/lib/agent-service.test.ts
@@ -8,12 +8,19 @@ let root = "";
 beforeEach(async () => { root = await mkdtemp(path.join(tmpdir(), "foundry-agent-")); process.env.RESUME_FOUNDRY_AGENT_STORE = path.join(root, "store.json"); process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET = "human-only"; process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT = "1"; });
 afterEach(async () => { delete process.env.RESUME_FOUNDRY_AGENT_STORE; delete process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET; delete process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT; await rm(root, { recursive: true, force: true }); });
 
-async function prepare() {
+async function importJob() {
   const imported = await executeAgentOperation({ operation: "jobs.import", input: { title: "Engineer", company: "Acme", description: "Build reliable TypeScript systems with testing and security." }, actor: "test" });
-  const jobId = (imported.result as { id: string }).id;
-  const prepared = await executeAgentOperation({ operation: "applications.prepare", input: { jobId, packet: { resume: "private" } }, actor: "test" });
+  return (imported.result as { id: string }).id;
+}
+
+async function prepare() {
+  const jobId = await importJob();
+  const prepared = await executeAgentOperation({ operation: "applications.prepare", input: { jobId, packet: { resume: "Jane Doe, SSN 555-00-1234" } }, actor: "test", piiApproved: true });
   return (prepared.result as { id: string }).id;
 }
+
+const approve = (applicationId: string) =>
+  executeAgentOperation({ operation: "applications.approve", input: { applicationId }, actor: "human", humanApprovalSecret: "human-only" });
 
 describe("agent policy service", () => {
   it("persists every allowed and denied action in a queryable audit log", async () => {
@@ -22,17 +29,57 @@ describe("agent policy service", () => {
     const audit = await queryAuditLog(); expect(audit).toHaveLength(2); expect(audit.map((entry) => entry.allowed)).toEqual([true, false]); expect(JSON.stringify(audit)).not.toContain("human-only");
     expect(JSON.parse(await readFile(process.env.RESUME_FOUNDRY_AGENT_STORE!, "utf8")).audit).toHaveLength(2);
   });
-  it("requires human approval and PII approval before handoff or submission", async () => {
+
+  it("requires PII approval to write or read back a stored packet", async () => {
+    // Regression: applications.prepare (which writes the packet server-side) and
+    // applications.review (which returns it verbatim) were both ungated, so any
+    // bearer holder could store and then read back every résumé and its personal
+    // identifiers with no approval of any kind.
+    const jobId = await importJob();
+    const writeDenied = await executeAgentOperation({ operation: "applications.prepare", input: { jobId, packet: { resume: "Jane Doe, SSN 555-00-1234" } }, actor: "agent" });
+    expect(writeDenied.ok).toBe(false);
+    expect(writeDenied.error).toMatch(/Protected PII disclosure/);
+
+    const id = await prepare();
+    const readDenied = await executeAgentOperation({ operation: "applications.review", input: { applicationId: id }, actor: "agent" });
+    expect(readDenied.ok).toBe(false);
+    expect(JSON.stringify(readDenied)).not.toContain("555-00-1234");
+    expect((await executeAgentOperation({ operation: "applications.review", input: { applicationId: id }, actor: "human", piiApproved: true })).ok).toBe(true);
+  });
+
+  it("requires human approval before approval, and PII approval before handoff", async () => {
     const id = await prepare();
     expect((await executeAgentOperation({ operation: "applications.approve", input: { applicationId: id }, actor: "agent" })).ok).toBe(false);
-    expect((await executeAgentOperation({ operation: "applications.approve", input: { applicationId: id }, actor: "human", humanApprovalSecret: "human-only" })).ok).toBe(true);
+    expect((await approve(id)).ok).toBe(true);
     expect((await executeAgentOperation({ operation: "applications.open_handoff", input: { applicationId: id }, actor: "agent" })).ok).toBe(false);
     expect((await executeAgentOperation({ operation: "applications.open_handoff", input: { applicationId: id }, actor: "agent", piiApproved: true })).ok).toBe(true);
   });
-  it("enforces the configured daily application limit", async () => {
-    const first = await prepare(); await executeAgentOperation({ operation: "applications.approve", input: { applicationId: first }, actor: "human", humanApprovalSecret: "human-only" });
+
+  it("counts an opened handoff against the daily limit", async () => {
+    // Regression: the limit guarded only mark_submitted — self-reported
+    // bookkeeping — so an agent that simply never called it could open unlimited
+    // handoffs, which is the step that actually discloses the packet.
+    const first = await prepare(); await approve(first);
+    expect((await executeAgentOperation({ operation: "applications.open_handoff", input: { applicationId: first }, actor: "human", piiApproved: true })).ok).toBe(true);
+    const second = await prepare(); await approve(second);
+    expect((await executeAgentOperation({ operation: "applications.open_handoff", input: { applicationId: second }, actor: "human", piiApproved: true })).error).toMatch(/Daily application limit/);
+  });
+
+  it("does not double-charge quota when one application progresses to submission", async () => {
+    const id = await prepare(); await approve(id);
+    expect((await executeAgentOperation({ operation: "applications.open_handoff", input: { applicationId: id }, actor: "human", piiApproved: true })).ok).toBe(true);
+    expect((await executeAgentOperation({ operation: "applications.mark_submitted", input: { applicationId: id }, actor: "human", piiApproved: true })).ok).toBe(true);
+  });
+
+  it("enforces the configured daily application limit on submission", async () => {
+    const first = await prepare(); await approve(first);
     expect((await executeAgentOperation({ operation: "applications.mark_submitted", input: { applicationId: first }, actor: "human", piiApproved: true })).ok).toBe(true);
-    const second = await prepare(); await executeAgentOperation({ operation: "applications.approve", input: { applicationId: second }, actor: "human", humanApprovalSecret: "human-only" });
+    const second = await prepare(); await approve(second);
     expect((await executeAgentOperation({ operation: "applications.mark_submitted", input: { applicationId: second }, actor: "human", piiApproved: true })).error).toMatch(/Daily application limit/);
+  });
+
+  it("fails closed when the durable store path is relative", async () => {
+    process.env.RESUME_FOUNDRY_AGENT_STORE = "relative/store.json";
+    expect((await executeAgentOperation({ operation: "jobs.search", input: {}, actor: "agent" })).ok).toBe(false);
   });
 });

--- a/lib/agent-service.ts
+++ b/lib/agent-service.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
@@ -18,7 +18,7 @@ const AgentRequestSchema = z.strictObject({
 export type AgentRequest = z.input<typeof AgentRequestSchema>;
 
 type StoredJob = { id: string; title: string; company: string; description: string; url: string; dismissed: boolean; importedAt: string };
-type StoredApplication = { id: string; jobId: string; state: "prepared" | "approved" | "handoff_opened" | "submitted"; packet: Record<string, unknown>; approvedAt: string | null; submittedAt: string | null; responses: unknown[]; followUps: string[] };
+type StoredApplication = { id: string; jobId: string; state: "prepared" | "approved" | "handoff_opened" | "submitted"; packet: Record<string, unknown>; approvedAt: string | null; submittedAt: string | null; /** First outward disclosure; consumes one unit of daily quota. */ disclosedAt?: string | null; responses: unknown[]; followUps: string[] };
 export type AuditEntry = { id: string; at: string; actor: string; operation: AgentOperation; allowed: boolean; reason: string; inputHash: string; resultId: string | null };
 type Store = { version: 1; jobs: StoredJob[]; applications: StoredApplication[]; audit: AuditEntry[] };
 const emptyStore = (): Store => ({ version: 1, jobs: [], applications: [], audit: [] });
@@ -26,6 +26,9 @@ const emptyStore = (): Store => ({ version: 1, jobs: [], applications: [], audit
 const storePath = () => {
   const configured = process.env.RESUME_FOUNDRY_AGENT_STORE?.trim();
   if (!configured) throw new Error("RESUME_FOUNDRY_AGENT_STORE must be configured for durable agent operations.");
+  // A relative path silently resolved against the process CWD — exactly the
+  // ephemeral deployment directory the documented guarantee promises to refuse.
+  if (!path.isAbsolute(configured)) throw new Error("RESUME_FOUNDRY_AGENT_STORE must be an absolute path on durable storage.");
   return configured;
 };
 async function loadStore(): Promise<Store> { try { return JSON.parse(await readFile(storePath(), "utf8")) as Store; } catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyStore(); throw error; } }
@@ -33,18 +36,56 @@ async function saveStore(store: Store) { const target = storePath(); await mkdir
 const hash = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
 const text = (value: unknown, name: string, minimum = 1) => { if (typeof value !== "string" || value.trim().length < minimum) throw new Error(`${name} is required.`); return value.trim(); };
 
+/**
+ * Operations that accept or return raw packet content — résumé text, cover
+ * letter, contact details. `applications.review` returns the entire stored
+ * packet and `applications.prepare` writes it, so both handle PII. Both were
+ * previously ungated, so any bearer holder could read back every stored résumé
+ * and its personal identifiers with no approval of any kind.
+ */
+const PII_OPERATIONS: readonly AgentOperation[] = [
+  "applications.prepare", "applications.review", "applications.open_handoff", "applications.mark_submitted",
+];
+
+function secretsMatch(supplied: unknown, expected: string) {
+  if (typeof supplied !== "string") return false;
+  const a = Buffer.from(supplied, "utf8"); const b = Buffer.from(expected, "utf8");
+  // Compare a fixed-size digest so differing lengths do not short-circuit.
+  return timingSafeEqual(createHash("sha256").update(a).digest(), createHash("sha256").update(b).digest());
+}
+
 function decision(operation: AgentOperation, request: z.output<typeof AgentRequestSchema>) {
   if (operation === "applications.approve") {
     const secret = process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET;
-    if (!secret || request.humanApprovalSecret !== secret) return { allowed: false, reason: "Explicit human approval secret is required." };
+    if (!secret || !secretsMatch(request.humanApprovalSecret, secret)) return { allowed: false, reason: "Explicit human approval secret is required." };
   }
-  if (["applications.open_handoff", "applications.mark_submitted"].includes(operation) && request.piiApproved !== true) return { allowed: false, reason: "Protected PII disclosure requires explicit approval." };
+  if (PII_OPERATIONS.includes(operation) && request.piiApproved !== true) return { allowed: false, reason: "Protected PII disclosure requires explicit approval." };
   return { allowed: true, reason: "Policy satisfied." };
+}
+
+/**
+ * Daily quota is consumed on the first outward disclosure of an application,
+ * whether that is opening a handoff or marking a submission. The limit
+ * previously guarded only `mark_submitted`, which is self-reported bookkeeping,
+ * so an agent that simply never called it could open unlimited handoffs.
+ */
+function assertDailyDisclosureAllowed(store: Store, application: StoredApplication, now: string) {
+  if (application.disclosedAt) return; // Already counted; later stages are free.
+  const limit = Number(process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT ?? 10);
+  const used = store.applications.filter((item) => item.disclosedAt && today(item.disclosedAt) === today(now)).length;
+  if (!Number.isInteger(limit) || limit < 1 || used >= limit) throw new Error("Daily application limit reached.");
+  application.disclosedAt = now;
 }
 
 function today(value: string) { return value.slice(0, 10); }
 async function executeAgentOperationInner(raw: AgentRequest) {
-  const request = AgentRequestSchema.parse(raw); const store = await loadStore(); const now = new Date().toISOString();
+  const request = AgentRequestSchema.parse(raw); const now = new Date().toISOString();
+  // `loadStore()` used to run outside this guard, so an EACCES/EISDIR or a
+  // corrupt store escaped to the route and returned the durable store's
+  // absolute filesystem path to the caller in `error.message`.
+  let store: Store;
+  try { store = await loadStore(); }
+  catch { return { ok: false, operation: request.operation, error: "The agent durable store is unavailable." }; }
   const permission = decision(request.operation, request); let result: unknown = null; let resultId: string | null = null;
   try {
     if (!permission.allowed) throw new Error(permission.reason);
@@ -56,11 +97,11 @@ async function executeAgentOperationInner(raw: AgentRequest) {
       case "jobs.compare": { const ids = Array.isArray(input.ids) ? input.ids : []; result = store.jobs.filter((job) => ids.includes(job.id)); break; }
       case "jobs.dismiss": { const job = store.jobs.find((item) => item.id === input.id); if (!job) throw new Error("Job not found."); job.dismissed = true; result = job; resultId = job.id; break; }
       case "matches.score": { const job = store.jobs.find((item) => item.id === input.jobId); if (!job) throw new Error("Job not found."); const evidence = Array.isArray(input.evidence) ? input.evidence.map(String) : []; const words = new Set(evidence.join(" ").toLowerCase().split(/\W+/u)); const terms = job.description.toLowerCase().split(/\W+/u).filter((term) => term.length > 3); const matched = [...new Set(terms.filter((term) => words.has(term)))]; result = { jobId: job.id, score: terms.length ? Math.round(matched.length / new Set(terms).size * 100) : 0, matched, policy: "lexical evidence only; no qualification inference" }; break; }
-      case "applications.prepare": { const job = store.jobs.find((item) => item.id === input.jobId); if (!job) throw new Error("Job not found."); const application: StoredApplication = { id: randomUUID(), jobId: job.id, state: "prepared", packet: structuredClone((input.packet ?? {}) as Record<string, unknown>), approvedAt: null, submittedAt: null, responses: [], followUps: [] }; store.applications.push(application); result = application; resultId = application.id; break; }
+      case "applications.prepare": { const job = store.jobs.find((item) => item.id === input.jobId); if (!job) throw new Error("Job not found."); const application: StoredApplication = { id: randomUUID(), jobId: job.id, state: "prepared", packet: structuredClone((input.packet ?? {}) as Record<string, unknown>), approvedAt: null, submittedAt: null, disclosedAt: null, responses: [], followUps: [] }; store.applications.push(application); result = application; resultId = application.id; break; }
       case "applications.review": { result = store.applications.find((item) => item.id === input.applicationId) ?? null; break; }
       case "applications.approve": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application || application.state !== "prepared") throw new Error("Only a prepared application can be approved."); application.state = "approved"; application.approvedAt = now; result = application; resultId = application.id; break; }
-      case "applications.open_handoff": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application || application.state !== "approved") throw new Error("Approved application required."); application.state = "handoff_opened"; result = application; resultId = application.id; break; }
-      case "applications.mark_submitted": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application || !["approved", "handoff_opened"].includes(application.state)) throw new Error("Approved application required."); const limit = Number(process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT ?? 10); const count = store.applications.filter((item) => item.submittedAt && today(item.submittedAt) === today(now)).length; if (!Number.isInteger(limit) || limit < 1 || count >= limit) throw new Error("Daily application limit reached."); application.state = "submitted"; application.submittedAt = now; result = application; resultId = application.id; break; }
+      case "applications.open_handoff": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application || application.state !== "approved") throw new Error("Approved application required."); assertDailyDisclosureAllowed(store, application, now); application.state = "handoff_opened"; result = application; resultId = application.id; break; }
+      case "applications.mark_submitted": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application || !["approved", "handoff_opened"].includes(application.state)) throw new Error("Approved application required."); assertDailyDisclosureAllowed(store, application, now); application.state = "submitted"; application.submittedAt = now; result = application; resultId = application.id; break; }
       case "applications.record_response": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application) throw new Error("Application not found."); application.responses.push({ at: now, value: input.response ?? null }); result = application; resultId = application.id; break; }
       case "applications.schedule_followup": { const application = store.applications.find((item) => item.id === input.applicationId); if (!application) throw new Error("Application not found."); const dueAt = text(input.dueAt, "dueAt"); if (!Number.isFinite(new Date(dueAt).getTime())) throw new Error("dueAt must be an ISO date."); application.followUps.push(new Date(dueAt).toISOString()); result = application; resultId = application.id; break; }
       case "analytics.summary": result = { jobs: store.jobs.length, activeJobs: store.jobs.filter((job) => !job.dismissed).length, applications: store.applications.length, submitted: store.applications.filter((item) => item.submittedAt).length }; break;

--- a/lib/agent-service.ts
+++ b/lib/agent-service.ts
@@ -142,4 +142,17 @@ export async function executeAgentOperation(raw: AgentRequest) {
   } finally { release(); }
 }
 
-export async function queryAuditLog(): Promise<AuditEntry[]> { return (await loadStore()).audit.map((entry) => ({ ...entry })); }
+/**
+ * Reads under the same lock as writes.
+ *
+ * `saveStore` replaces the file by rename. An unlocked read landing in that
+ * window sees ENOENT, which `loadStore` legitimately maps to an empty store for
+ * the first-run case — so the audit trail would come back empty rather than
+ * missing, which is the more dangerous of the two failures.
+ */
+export async function queryAuditLog(): Promise<AuditEntry[]> {
+  const read = async () => (await loadStore()).audit.map((entry) => ({ ...entry }));
+  let lockPath: string | null = null;
+  try { lockPath = `${storePath()}.lock`; } catch { lockPath = null; }
+  return lockPath ? withFileLock(lockPath, read) : read();
+}

--- a/lib/agent-service.ts
+++ b/lib/agent-service.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
+import { withFileLock } from "./file-lock.ts";
 
 export const AGENT_OPERATIONS = [
   "jobs.import", "jobs.search", "jobs.get", "jobs.compare", "jobs.dismiss", "matches.score",
@@ -110,16 +111,35 @@ async function executeAgentOperationInner(raw: AgentRequest) {
     await saveStore(store); return { ok: true, operation: request.operation, result };
   } catch (error) {
     store.audit.push({ id: randomUUID(), at: now, actor: request.actor, operation: request.operation, allowed: false, reason: error instanceof Error ? error.message : "Operation denied.", inputHash: hash(request.input), resultId: null });
-    await saveStore(store); return { ok: false, operation: request.operation, error: error instanceof Error ? error.message : "Operation denied." };
+    // This save previously ran unguarded inside the failure path, so a rename
+    // race surfaced as an uncaught EPERM that killed the process.
+    await saveStore(store).catch(() => undefined);
+    return { ok: false, operation: request.operation, error: error instanceof Error ? error.message : "Operation denied." };
   }
 }
 
 let operationQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Serialises every operation, first within this process and then across
+ * processes.
+ *
+ * The in-process queue alone left the whole-file read-modify-write open to a
+ * lost-update race: four concurrent processes each read the same store, all
+ * four passed a daily limit of one, and three writes vanished.
+ */
 export async function executeAgentOperation(raw: AgentRequest) {
   const preceding = operationQueue; let release!: () => void;
   operationQueue = new Promise<void>((resolve) => { release = resolve; });
   await preceding;
-  try { return await executeAgentOperationInner(raw); } finally { release(); }
+  try {
+    let lockPath: string | null = null;
+    // An unset or relative store path is reported by the inner call, which
+    // returns a generic failure rather than echoing the configured path.
+    try { lockPath = `${storePath()}.lock`; } catch { lockPath = null; }
+    if (!lockPath) return await executeAgentOperationInner(raw);
+    return await withFileLock(lockPath, () => executeAgentOperationInner(raw));
+  } finally { release(); }
 }
 
 export async function queryAuditLog(): Promise<AuditEntry[]> { return (await loadStore()).audit.map((entry) => ({ ...entry })); }

--- a/lib/agent-store-concurrency.test.ts
+++ b/lib/agent-store-concurrency.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { executeAgentOperation } from "./agent-service";
+
+const run = promisify(execFile);
+const probe = path.join(import.meta.dirname, "testdata", "agent-operation-probe.ts");
+
+let root = "";
+let store = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "foundry-race-"));
+  store = path.join(root, "store.json");
+  process.env.RESUME_FOUNDRY_AGENT_STORE = store;
+  process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET = "human-only";
+  process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT = "1";
+});
+afterEach(async () => {
+  delete process.env.RESUME_FOUNDRY_AGENT_STORE;
+  delete process.env.RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET;
+  delete process.env.RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT;
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Runs one operation in its own OS process against the same store. */
+async function inChildProcess(request: unknown) {
+  const { stdout } = await run(process.execPath, ["--experimental-strip-types", probe, store, JSON.stringify(request)], {
+    env: { ...process.env, RESUME_FOUNDRY_AGENT_STORE: store },
+    timeout: 60_000,
+  });
+  return JSON.parse(stdout) as { ok: boolean; error?: string };
+}
+
+async function approvedApplications(count: number) {
+  const imported = await executeAgentOperation({ operation: "jobs.import", input: { title: "Engineer", company: "Acme", description: "Build reliable TypeScript systems with testing and security." }, actor: "test" });
+  const jobId = (imported.result as { id: string }).id;
+  const ids: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const prepared = await executeAgentOperation({ operation: "applications.prepare", input: { jobId, packet: { resume: "synthetic" } }, actor: "test", piiApproved: true });
+    const id = (prepared.result as { id: string }).id;
+    await executeAgentOperation({ operation: "applications.approve", input: { applicationId: id }, actor: "human", humanApprovalSecret: "human-only" });
+    ids.push(id);
+  }
+  return ids;
+}
+
+describe("agent store cross-process safety", () => {
+  it("enforces the daily limit across concurrent independent processes", async () => {
+    // Regression: with an in-process promise queue only, four separate processes
+    // each read the same store, all four were told submission was authorized
+    // under a limit of one, and three writes were lost.
+    const ids = await approvedApplications(4);
+    const results = await Promise.all(ids.map((applicationId) =>
+      inChildProcess({ operation: "applications.mark_submitted", input: { applicationId }, actor: "racer", piiApproved: true })));
+
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    for (const denied of results.filter((result) => !result.ok)) {
+      expect(denied.error).toMatch(/Daily application limit/);
+    }
+    const persisted = JSON.parse(await readFile(store, "utf8")) as { applications: { submittedAt: string | null }[] };
+    expect(persisted.applications.filter((application) => application.submittedAt)).toHaveLength(1);
+  }, 120_000);
+
+  it("loses no audit entry when independent processes write concurrently", async () => {
+    // Regression: last-writer-wins on the whole file silently dropped audit
+    // rows — 13 expected, 11 or 12 observed.
+    const before = (JSON.parse(await readFile(store, "utf8").catch(() => '{"audit":[]}')) as { audit: unknown[] }).audit.length;
+    const searches = Array.from({ length: 6 }, (_, index) =>
+      inChildProcess({ operation: "jobs.search", input: { query: `q${index}` }, actor: `racer-${index}` }));
+    const results = await Promise.all(searches);
+    expect(results.every((result) => result.ok)).toBe(true);
+
+    const persisted = JSON.parse(await readFile(store, "utf8")) as { audit: unknown[] };
+    expect(persisted.audit.length).toBe(before + 6);
+  }, 120_000);
+});

--- a/lib/anthropic-model.test.ts
+++ b/lib/anthropic-model.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MODEL, resolveModel } from "./anthropic-model";
+
+describe("Anthropic model resolution", () => {
+  it("ignores ANTHROPIC_MODEL so a CLI alias cannot hijack the production route", () => {
+    // Regression: the resolver used to fall back to ANTHROPIC_MODEL, which the
+    // Claude Code CLI sets globally. On a developer machine it resolved to
+    // "opusplan" — not a valid API model id — so every tailoring request was
+    // sent with a broken model by default.
+    expect(resolveModel({ ANTHROPIC_MODEL: "opusplan" })).toBe(DEFAULT_MODEL);
+    expect(resolveModel({ ANTHROPIC_MODEL: "claude-sonnet-5" })).toBe(DEFAULT_MODEL);
+  });
+
+  it("defaults to claude-opus-5 when nothing is configured", () => {
+    expect(resolveModel({})).toBe("claude-opus-5");
+    expect(resolveModel({ RESUME_FOUNDRY_ANTHROPIC_MODEL: "   " })).toBe("claude-opus-5");
+  });
+
+  it("honours a valid app-specific override", () => {
+    expect(resolveModel({ RESUME_FOUNDRY_ANTHROPIC_MODEL: "claude-sonnet-5" })).toBe("claude-sonnet-5");
+    expect(resolveModel({ RESUME_FOUNDRY_ANTHROPIC_MODEL: " claude-haiku-4-5-20251001 " })).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("rejects CLI aliases and other non-model identifiers with an actionable error", () => {
+    for (const alias of ["opusplan", "opus", "sonnet", "default", "haiku"]) {
+      expect(() => resolveModel({ RESUME_FOUNDRY_ANTHROPIC_MODEL: alias })).toThrow(/not a valid Anthropic model id/);
+    }
+  });
+});

--- a/lib/anthropic-model.ts
+++ b/lib/anthropic-model.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_MODEL = "claude-opus-5";
+
+/**
+ * Resolves the Anthropic model id for the tailoring route.
+ *
+ * Only an app-specific variable may override the default. `ANTHROPIC_MODEL`
+ * used to sit in a fallback chain here, and the Claude Code CLI sets that
+ * variable globally — so on any machine with the CLI installed the route
+ * resolved to the alias `opusplan`, which is not a valid API model id, and the
+ * product's core request failed by default. A comment directly above the chain
+ * asserted this could not happen; the chain itself was the defect.
+ */
+export function resolveModel(env: Record<string, string | undefined> = process.env): string {
+  const configured = env.RESUME_FOUNDRY_ANTHROPIC_MODEL?.trim();
+  if (!configured) return DEFAULT_MODEL;
+  // Fail with an actionable message rather than forwarding an unknown
+  // identifier and surfacing an opaque provider error at request time.
+  if (!/^[a-z][a-z0-9.]*-[a-z0-9.-]+$/u.test(configured)) {
+    throw new Error(
+      `RESUME_FOUNDRY_ANTHROPIC_MODEL="${configured}" is not a valid Anthropic model id (expected e.g. "claude-opus-5"). ` +
+      'CLI aliases such as "opusplan" are not API model ids.',
+    );
+  }
+  return configured;
+}

--- a/lib/applications.ts
+++ b/lib/applications.ts
@@ -1,6 +1,7 @@
 import type { TailorResult } from "./schema";
 import type { JobPostingSnapshot } from "./schema";
 import { sha256 } from "./job-inbox";
+import { canonicalJson } from "./canonical-json";
 
 export const APPLICATION_STATES = [
   "discovered", "saved", "reviewing", "tailoring", "ready", "submitted",
@@ -60,11 +61,14 @@ export interface ApplicationRecord {
   reminders: ApplicationReminder[];
 }
 
-function canonical(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
-  if (value && typeof value === "object") return `{${Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`).join(",")}}`;
-  return JSON.stringify(value);
-}
+// Packet checksums previously ordered keys with `localeCompare`, which is locale-
+// and ICU-dependent: "a" sorts before "A" under en-US but after it by code unit.
+// `screeningAnswers` keys are employer-supplied question names, so two hosts
+// could compute different checksums for the same packet and a packet sealed on
+// one machine would fail verification on another. Submission now gates on
+// `verifyApplicationPacket`, which makes that a correctness risk rather than a
+// latent one. The shared canonicaliser orders by code unit.
+const canonical = canonicalJson;
 
 export async function createApplicationPacket(input: {
   jobSnapshot: JobPostingSnapshot;

--- a/lib/canonical-json.test.ts
+++ b/lib/canonical-json.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { canonicalJson } from "./canonical-json";
+
+describe("canonicalJson", () => {
+  it("orders keys by code unit, not by locale", () => {
+    // Regression: packet checksums ordered keys with `localeCompare`, which puts
+    // "a" before "A" under en-US but after it by code unit. Employer-supplied
+    // screening-question names reach that sort, so the same packet could hash
+    // differently on two hosts and fail verification on the second.
+    expect(canonicalJson({ a: 1, A: 2 })).toBe('{"A":2,"a":1}');
+    expect("a".localeCompare("A")).toBe(-1); // pins the divergent behaviour
+  });
+
+  it("is independent of insertion order", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe(canonicalJson({ a: { c: 3, d: 2 }, b: 1 }));
+  });
+
+  it("preserves array order and nests objects", () => {
+    expect(canonicalJson({ list: [{ b: 1, a: 2 }, "x"] })).toBe('{"list":[{"a":2,"b":1},"x"]}');
+  });
+
+  it("drops undefined members rather than emitting invalid JSON", () => {
+    expect(canonicalJson({ a: 1, b: undefined })).toBe('{"a":1}');
+    expect(canonicalJson([1, undefined, 2])).toBe("[1,null,2]");
+  });
+
+  it("refuses values that cannot be signed deterministically", () => {
+    expect(() => canonicalJson(undefined)).toThrow(/undefined/);
+    expect(() => canonicalJson({ a: Number.NaN })).toThrow(/Non-finite/);
+    expect(() => canonicalJson({ a: Number.POSITIVE_INFINITY })).toThrow(/Non-finite/);
+  });
+});

--- a/lib/canonical-json.ts
+++ b/lib/canonical-json.ts
@@ -1,0 +1,25 @@
+/**
+ * Deterministic JSON for signing and hashing.
+ *
+ * The submission receipt previously MAC'd `JSON.stringify(unsigned)`, which
+ * preserves the *insertion* order of whatever object it was handed. That made
+ * verification depend on JSON transport happening to round-trip key order, so
+ * any client that reconstructed the receipt produced a verification failure
+ * indistinguishable from tampering.
+ *
+ * Keys are ordered by UTF-16 code unit, not `localeCompare`, because
+ * `localeCompare` is locale- and ICU-dependent and would make a signature
+ * verify on one host and fail on another.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) throw new Error("undefined cannot be canonicalised.");
+  if (value === null || typeof value !== "object") {
+    if (typeof value === "number" && !Number.isFinite(value)) throw new Error("Non-finite numbers cannot be canonicalised.");
+    return JSON.stringify(value) as string;
+  }
+  if (Array.isArray(value)) return `[${value.map((entry) => canonicalJson(entry ?? null)).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`;
+}

--- a/lib/file-lock.ts
+++ b/lib/file-lock.ts
@@ -1,0 +1,52 @@
+import { open, stat, unlink } from "node:fs/promises";
+
+/**
+ * Cross-process mutual exclusion for a whole-file read-modify-write.
+ *
+ * The agent store is read, mutated, and rewritten in full. That was serialised
+ * only by a module-scoped promise queue, which holds within one Node process and
+ * not between them — four concurrent processes each read the same store, all
+ * four passed a daily limit of one, and three writes were lost.
+ *
+ * Acquisition is a single `open(O_CREAT|O_EXCL)`, the same atomic primitive the
+ * nonce store uses. A lock older than `staleAfterMs` is reclaimed so a killed
+ * process cannot wedge the store permanently.
+ */
+export async function withFileLock<T>(
+  lockPath: string,
+  work: () => Promise<T>,
+  options: { timeoutMs?: number; staleAfterMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const staleAfterMs = options.staleAfterMs ?? 30_000;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      await handle.close();
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      await reclaimIfStale(lockPath, staleAfterMs);
+      if (Date.now() >= deadline) throw new Error("Timed out waiting for the durable store lock.");
+      // Jittered backoff so waiters do not retry in lockstep.
+      await new Promise((resolve) => setTimeout(resolve, 5 + Math.floor(Math.random() * 15)));
+    }
+  }
+
+  try {
+    return await work();
+  } finally {
+    await unlink(lockPath).catch(() => undefined);
+  }
+}
+
+async function reclaimIfStale(lockPath: string, staleAfterMs: number) {
+  try {
+    const info = await stat(lockPath);
+    if (Date.now() - info.mtimeMs > staleAfterMs) await unlink(lockPath).catch(() => undefined);
+  } catch {
+    // Already gone; the next acquisition attempt will win or lose cleanly.
+  }
+}

--- a/lib/mcp-server.test.ts
+++ b/lib/mcp-server.test.ts
@@ -1,24 +1,80 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { execFile } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { AGENT_OPERATIONS } from "./agent-service";
-import { createResumeFoundryMcpServer } from "../scripts/mcp-server";
+import { assertMcpEnabled, createResumeFoundryMcpServer, MCP_OPERATIONS } from "../scripts/mcp-server";
+
+const run = promisify(execFile);
+const serverPath = path.join(import.meta.dirname, "..", "scripts", "mcp-server.ts");
 
 let root = "";
 beforeEach(async () => { root = await mkdtemp(path.join(tmpdir(), "foundry-mcp-")); process.env.RESUME_FOUNDRY_AGENT_STORE = path.join(root, "store.json"); });
 afterEach(async () => { delete process.env.RESUME_FOUNDRY_AGENT_STORE; await rm(root, { recursive: true, force: true }); });
+
 describe("MCP protocol", () => {
-  it("lists every operation and executes through the shared policy service", async () => {
+  it("starts under native Node type stripping", async () => {
+    // Regression: `../lib/agent-service` carried no extension, and
+    // `node --experimental-strip-types` performs no ESM extension resolution,
+    // so `npm run mcp` died with ERR_MODULE_NOT_FOUND. The suite missed it
+    // because vitest resolves bundler-style. This spawns the real entrypoint,
+    // so a resolution failure surfaces as ERR_MODULE_NOT_FOUND rather than the
+    // expected opt-in refusal.
+    const result = await run(process.execPath, ["--experimental-strip-types", serverPath], {
+      env: { ...process.env, RESUME_FOUNDRY_MCP_ENABLED: "" }, timeout: 30_000,
+    }).catch((error: { stderr?: string }) => error);
+    const stderr = (result as { stderr?: string }).stderr ?? "";
+    expect(stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+    expect(stderr).toContain("RESUME_FOUNDRY_MCP_ENABLED");
+  }, 40_000);
+
+  it("refuses to expose the stdio surface without an explicit opt-in", () => {
+    // stdio has no bearer token to check — its real trust boundary is the local
+    // user who launched the process. The docs previously claimed bearer auth for
+    // MCP, which was untrue.
+    expect(() => assertMcpEnabled({})).toThrow(/RESUME_FOUNDRY_MCP_ENABLED/);
+    expect(() => assertMcpEnabled({ RESUME_FOUNDRY_MCP_ENABLED: "1" })).toThrow(/RESUME_FOUNDRY_MCP_ENABLED/);
+    expect(() => assertMcpEnabled({ RESUME_FOUNDRY_MCP_ENABLED: "true" })).not.toThrow();
+  });
+
+  it("never exposes an approval secret or a PII flag as a model-suppliable argument", async () => {
+    // Regression: every tool advertised `humanApprovalSecret`, publishing a
+    // human-held secret into the model's own context and letting the model
+    // approve on the human's behalf — while the HTTP route deliberately accepts
+    // that secret only from a header.
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const server = createResumeFoundryMcpServer(); const client = new Client({ name: "test", version: "1" });
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-    const tools = await client.listTools(); expect(tools.tools.map((tool) => tool.name).sort()).toEqual([...AGENT_OPERATIONS].sort());
+    const schemas = JSON.stringify((await client.listTools()).tools.map((tool) => tool.inputSchema));
+    expect(schemas).not.toContain("humanApprovalSecret");
+    expect(schemas).not.toContain("piiApproved");
+    await client.close(); await server.close();
+  });
+
+  it("withholds approval-gated and PII-bearing operations from stdio", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createResumeFoundryMcpServer(); const client = new Client({ name: "test", version: "1" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const names = (await client.listTools()).tools.map((tool) => tool.name);
+    expect(names.sort()).toEqual([...MCP_OPERATIONS].sort());
+    for (const withheld of ["applications.approve", "applications.prepare", "applications.review", "applications.open_handoff", "applications.mark_submitted"]) {
+      expect(names).not.toContain(withheld);
+    }
+    expect(MCP_OPERATIONS.length).toBeLessThan(AGENT_OPERATIONS.length);
+    await client.close(); await server.close();
+  });
+
+  it("executes an exposed operation through the shared policy service", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createResumeFoundryMcpServer(); const client = new Client({ name: "test", version: "1" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     const result = await client.callTool({ name: "jobs.import", arguments: { input: { title: "Engineer", company: "Acme", description: "Build secure and reliable software systems." } } });
     expect(result.isError).not.toBe(true);
-    const content = (result as { content: { type: string; text?: string }[] }).content[0]; expect(content.type).toBe("text");
+    const content = (result as { content: { type: string; text?: string }[] }).content[0];
     expect(JSON.parse(content.type === "text" ? (content.text ?? "{}") : "{}")).toMatchObject({ ok: true, operation: "jobs.import" });
     await client.close(); await server.close();
   });

--- a/lib/nonce-store.test.ts
+++ b/lib/nonce-store.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { configuredNonceStore, createDurableNonceStore, createInMemoryNonceStore } from "./nonce-store";
+
+const freshDirectory = () => path.join(mkdtempSync(path.join(tmpdir(), "rf-nonce-")), "store");
+const probe = path.join(import.meta.dirname, "testdata", "consume-nonce-probe.ts");
+
+describe("nonce store", () => {
+  it("consumes a nonce exactly once in a single process", () => {
+    const store = createDurableNonceStore({ directory: freshDirectory() });
+    expect(store.consume("nonce-a")).toBe(true);
+    expect(store.consume("nonce-a")).toBe(false);
+    expect(store.consume("nonce-b")).toBe(true);
+  });
+
+  it("consumes a nonce exactly once across concurrent independent processes", () => {
+    // Regression for the original defect: the submission ledger serialised
+    // writes with a module-scoped promise queue, so two module instances each
+    // read consumed:[] and both proceeded to transmit. Reproduced previously as
+    // two fulfilled consumes with one lost write.
+    const directory = freshDirectory();
+    const results = Array.from({ length: 8 }, () =>
+      execFileSync(process.execPath, ["--experimental-strip-types", probe, directory, "contended-nonce"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    );
+    expect(results.filter((r) => r === "WON")).toHaveLength(1);
+    expect(results.filter((r) => r === "LOST")).toHaveLength(7);
+  });
+
+  it("derives a safe filename so a hostile nonce cannot traverse paths", () => {
+    const directory = freshDirectory();
+    const store = createDurableNonceStore({ directory });
+    expect(store.consume("../../../../etc/passwd")).toBe(true);
+    expect(store.consume("../../../../etc/passwd")).toBe(false);
+    const entries = readdirSync(directory);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatch(/^[a-f0-9]{64}\.used$/u);
+  });
+
+  it("treats distinct nonces as distinct even when hostile", () => {
+    const store = createDurableNonceStore({ directory: freshDirectory() });
+    expect(store.consume("a/../b")).toBe(true);
+    expect(store.consume("b")).toBe(true);
+  });
+
+  it("rejects a relative directory and a replay-opening ttl", () => {
+    expect(() => createDurableNonceStore({ directory: "relative/dir" })).toThrow(/absolute/i);
+    expect(() => createDurableNonceStore({ directory: "" })).toThrow(/absolute directory/i);
+    expect(() => createDurableNonceStore({ directory: freshDirectory(), ttlMs: 5 })).toThrow(/at least/i);
+  });
+
+  it("rejects an empty nonce", () => {
+    const store = createDurableNonceStore({ directory: freshDirectory() });
+    expect(() => store.consume("")).toThrow(/nonce is required/i);
+  });
+
+  it("does not resurrect a nonce whose marker is still inside its ttl", () => {
+    const directory = freshDirectory();
+    const store = createDurableNonceStore({ directory, ttlMs: 60_000 });
+    expect(store.consume("kept")).toBe(true);
+    expect(store.consume("kept")).toBe(false);
+  });
+
+  it("prunes only markers older than the ttl", () => {
+    const directory = freshDirectory();
+    const store = createDurableNonceStore({ directory, ttlMs: 60_000 });
+    expect(store.consume("stale")).toBe(true);
+    const [marker] = readdirSync(directory);
+    const longAgo = new Date(Date.now() - 10 * 60_000);
+    utimesSync(path.join(directory, marker), longAgo, longAgo);
+    // A fresh store instance so the throttle does not suppress the sweep.
+    const later = createDurableNonceStore({ directory, ttlMs: 60_000 });
+    later.consume("unrelated");
+    expect(readdirSync(directory)).not.toContain(marker);
+  });
+
+  it("fails closed when the store directory is not configured", () => {
+    const previous = process.env.RESUME_FOUNDRY_NONCE_STORE;
+    try {
+      delete process.env.RESUME_FOUNDRY_NONCE_STORE;
+      expect(() => configuredNonceStore()).toThrow(/RESUME_FOUNDRY_NONCE_STORE must be configured/);
+      process.env.RESUME_FOUNDRY_NONCE_STORE = "   ";
+      expect(() => configuredNonceStore()).toThrow(/RESUME_FOUNDRY_NONCE_STORE must be configured/);
+    } finally {
+      if (previous === undefined) delete process.env.RESUME_FOUNDRY_NONCE_STORE;
+      else process.env.RESUME_FOUNDRY_NONCE_STORE = previous;
+    }
+  });
+
+  it("keeps the in-memory store single-use for tests", () => {
+    const store = createInMemoryNonceStore();
+    expect(store.consume("x")).toBe(true);
+    expect(store.consume("x")).toBe(false);
+  });
+});

--- a/lib/nonce-store.ts
+++ b/lib/nonce-store.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import { closeSync, mkdirSync, openSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Single-use nonce claim.
+ *
+ * `consume` must return `true` for exactly one caller per nonce, across every
+ * process sharing the store. The previous submission ledger used a
+ * module-scoped promise queue plus a read-modify-write of one JSON file, which
+ * serialises only within a single Node process — two module instances (or two
+ * Next.js workers) both consumed the same nonce and one write was lost.
+ *
+ * Synchronous by design so callers can consume a nonce as the last step of an
+ * already-synchronous verification path without introducing an await point.
+ */
+export interface NonceStore {
+  consume(nonce: string): boolean;
+}
+
+/** Volatile store for unit tests. Never use in a deployment. */
+export function createInMemoryNonceStore(): NonceStore {
+  const used = new Set<string>();
+  return {
+    consume(nonce) {
+      if (used.has(nonce)) return false;
+      used.add(nonce);
+      return true;
+    },
+  };
+}
+
+export interface DurableNonceStoreOptions {
+  /** Absolute directory on durable, access-controlled storage. */
+  directory: string;
+  /**
+   * Retention for consumed markers. Must exceed the maximum lifetime of
+   * anything the nonce protects, or pruning would re-open a replay window.
+   * Omit to retain markers forever.
+   */
+  ttlMs?: number;
+}
+
+const MIN_TTL_MS = 60_000;
+
+/**
+ * Cross-process durable store.
+ *
+ * Atomicity comes from a single `open(O_CREAT|O_EXCL)` per nonce — the marker
+ * file either did not exist and this caller created it, or it existed and this
+ * caller loses. There is no read-then-write window for a concurrent process to
+ * interleave with, and no lock to leak on crash.
+ *
+ * The filename is a SHA-256 hex digest of the nonce, so an attacker-supplied
+ * nonce cannot traverse paths, collide with a reserved device name, or exceed
+ * the filesystem's name length limit.
+ */
+export function createDurableNonceStore(options: DurableNonceStoreOptions): NonceStore {
+  const directory = options.directory?.trim();
+  if (!directory) throw new Error("A durable nonce store requires an absolute directory.");
+  if (!path.isAbsolute(directory)) throw new Error("The nonce store directory must be an absolute path.");
+  if (options.ttlMs !== undefined && (!Number.isFinite(options.ttlMs) || options.ttlMs < MIN_TTL_MS)) {
+    throw new Error(`A nonce store ttlMs must be at least ${MIN_TTL_MS}ms so pruning cannot re-open a replay window.`);
+  }
+
+  const markerFor = (nonce: string) =>
+    path.join(directory, `${createHash("sha256").update(nonce, "utf8").digest("hex")}.used`);
+
+  let ensured = false;
+  const ensureDirectory = () => {
+    if (ensured) return;
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    ensured = true;
+  };
+
+  // Per-instance so one store's sweep cannot suppress another's.
+  let lastPruneAt = 0;
+
+  return {
+    consume(nonce) {
+      if (typeof nonce !== "string" || nonce.length === 0) throw new Error("A nonce is required.");
+      ensureDirectory();
+      if (options.ttlMs !== undefined && Date.now() - lastPruneAt >= PRUNE_INTERVAL_MS) {
+        lastPruneAt = Date.now();
+        prune(directory, options.ttlMs);
+      }
+      try {
+        // O_CREAT|O_EXCL — the atomic claim. EEXIST means someone else won.
+        closeSync(openSync(markerFor(nonce), "wx", 0o600));
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+        throw error;
+      }
+    },
+  };
+}
+
+const PRUNE_INTERVAL_MS = 60_000;
+
+function prune(directory: string, ttlMs: number) {
+  const now = Date.now();
+  let entries: string[];
+  try {
+    entries = readdirSync(directory);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".used")) continue;
+    const file = path.join(directory, entry);
+    try {
+      if (now - statSync(file).mtimeMs > ttlMs) unlinkSync(file);
+    } catch {
+      // A concurrent pruner removed it, or it is not ours to remove.
+    }
+  }
+}
+
+/**
+ * Store backed by `RESUME_FOUNDRY_NONCE_STORE`. Fails closed when unset rather
+ * than silently degrading to per-process memory, which would make replay
+ * protection depend on how many workers happen to be running.
+ */
+export function configuredNonceStore(ttlMs?: number): NonceStore {
+  const directory = process.env.RESUME_FOUNDRY_NONCE_STORE?.trim();
+  if (!directory) {
+    throw new Error("RESUME_FOUNDRY_NONCE_STORE must be configured with an absolute durable directory for replay protection.");
+  }
+  return createDurableNonceStore({ directory, ttlMs });
+}

--- a/lib/submission-connectors.test.ts
+++ b/lib/submission-connectors.test.ts
@@ -1,38 +1,144 @@
 import { describe, expect, it, vi } from "vitest";
-import { createGmailDraft, greenhouseRequiredFields, issueSubmissionApproval, submitGreenhouse, submitLever, verifySubmissionApproval, type SubmissionPreview } from "./submission-connectors";
+import { assertApprovedPacket, createGmailDraft, greenhouseRequiredFields, issueSubmissionApproval, submitGreenhouse, submitLever, verifySubmissionApproval, type SubmissionPreview, type SubmissionTarget } from "./submission-connectors";
 
 const secret = "this-is-a-human-approval-secret";
-const preview = (provider: "greenhouse" | "lever" | "gmail"): SubmissionPreview => ({ applicationId: "app-1", provider, company: "Acme", role: "Engineer", destination: "https://example.com/apply", packetVersion: 2, resumeChecksum: "a".repeat(64), coverLetterChecksum: "b".repeat(64), personalDataCategories: ["email"], fields: { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" }, createdAt: "2026-01-01T00:00:00.000Z" });
+
+const targets: Record<SubmissionPreview["provider"], SubmissionTarget> = {
+  greenhouse: { provider: "greenhouse", boardToken: "approved-board", jobId: "111" },
+  lever: { provider: "lever", site: "approved-site", postingId: "222", requiredFields: ["name"] },
+  gmail: { provider: "gmail", rawMessage: "To: jobs@example.com\r\nSubject: Application\r\n\r\nHello" },
+};
+
+const preview = (provider: "greenhouse" | "lever" | "gmail"): SubmissionPreview => ({
+  applicationId: "app-1", provider, company: "Acme", role: "Engineer",
+  destination: "https://example.com/apply", packetVersion: 2,
+  resumeChecksum: "a".repeat(64), coverLetterChecksum: "b".repeat(64), packetChecksum: "c".repeat(64),
+  personalDataCategories: ["email"],
+  fields: { first_name: "Ada", last_name: "Lovelace", name: "Ada Lovelace", email: "ada@example.com", resume_text: "APPROVED RESUME" },
+  createdAt: "2026-01-01T00:00:00.000Z", target: structuredClone(targets[provider]),
+});
+
 describe("authorized submission connectors", () => {
-  it("binds approval to exact preview and rejects mutation or expiry", () => {
+  it("binds approval to the exact preview and rejects mutation or expiry", () => {
     const receipt = issueSubmissionApproval(preview("greenhouse"), secret, new Date("2026-01-01T00:00:00Z"));
     expect(verifySubmissionApproval(receipt, secret, new Date("2026-01-01T00:01:00Z"))).toEqual(preview("greenhouse"));
     const tampered = structuredClone(receipt); tampered.preview.role = "Different";
     expect(() => verifySubmissionApproval(tampered, secret, new Date("2026-01-01T00:01:00Z"))).toThrow(/invalid/);
-    expect(() => verifySubmissionApproval(receipt, secret, new Date("2026-01-01T00:11:00Z"))).toThrow(/expired/);
+    expect(() => verifySubmissionApproval(receipt, secret, new Date("2026-01-01T00:11:00Z"))).toThrow(/invalid or expired/);
   });
+
+  it("transmits only the approved destination and the approved fields", async () => {
+    // Regression for the central defect: the execute route passed boardToken,
+    // jobId, and fields straight from the unsigned request body, so a receipt
+    // approved for one board was accepted while an entirely different résumé
+    // was POSTed to an entirely different board — returning accepted: true with
+    // the approved applicationId. The connector now exposes no parameter
+    // through which that substitution can be expressed.
+    const receipt = issueSubmissionApproval(preview("greenhouse"), secret);
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ questions: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    expect((await submitGreenhouse({ apiKey: "server-secret", receipt, approvalSecret: secret }, fetcher)).accepted).toBe(true);
+
+    const post = fetcher.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === "POST")!;
+    expect(post[0]).toBe("https://boards-api.greenhouse.io/v1/boards/approved-board/jobs/111");
+    expect(JSON.parse((post[1] as RequestInit).body as string)).toEqual(preview("greenhouse").fields);
+    expect(JSON.stringify(fetcher.mock.calls)).not.toContain("server-secret");
+  });
+
+  it("rejects a receipt whose expiresAt is malformed instead of treating it as eternal", () => {
+    // Regression: `new Date("not-a-date") <= now` is false, so a receipt with a
+    // malformed expiresAt never expired. expiresAt is inside the MAC, so this
+    // was reachable by anyone holding the signing key — which every caller of
+    // the approval endpoint necessarily does.
+    const receipt = issueSubmissionApproval(preview("greenhouse"), secret);
+    for (const bad of ["not-a-date", "", "9999-99-99T00:00:00Z"]) {
+      expect(() => verifySubmissionApproval({ ...structuredClone(receipt), expiresAt: bad }, secret, new Date("2099-01-01T00:00:00Z")))
+        .toThrow(/invalid or expired/);
+    }
+  });
+
+  it("rejects a validly signed receipt that grants itself a longer window than policy", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const receipt = issueSubmissionApproval(preview("greenhouse"), secret, now);
+    // Same secret, but a year-long window rather than the ten-minute policy.
+    const forged = { preview: receipt.preview, approvedAt: receipt.approvedAt, expiresAt: "2027-01-01T00:00:00.000Z", nonce: receipt.nonce };
+    const signature = issueSubmissionApproval(preview("greenhouse"), secret, now).signature;
+    expect(() => verifySubmissionApproval({ ...forged, signature }, secret, now)).toThrow(/invalid or expired/);
+  });
+
+  it("verifies regardless of JSON key order", () => {
+    // The MAC covered JSON.stringify(unsigned), which preserves insertion
+    // order, so any client that rebuilt the object failed verification in a way
+    // indistinguishable from tampering.
+    const receipt = issueSubmissionApproval(preview("greenhouse"), secret, new Date("2026-01-01T00:00:00Z"));
+    const reordered = JSON.parse(JSON.stringify({
+      signature: receipt.signature, nonce: receipt.nonce, expiresAt: receipt.expiresAt,
+      approvedAt: receipt.approvedAt, preview: receipt.preview,
+    }));
+    expect(verifySubmissionApproval(reordered, secret, new Date("2026-01-01T00:01:00Z")).applicationId).toBe("app-1");
+  });
+
+  it("refuses to issue a receipt whose signed target disagrees with the preview provider", () => {
+    const mismatched = { ...preview("greenhouse"), target: structuredClone(targets.lever) } as unknown as SubmissionPreview;
+    expect(() => issueSubmissionApproval(mismatched, secret)).toThrow();
+  });
+
+  it("binds the exact frozen packet, résumé, and cover letter", () => {
+    const approved = preview("greenhouse");
+    const good = { packet: "c".repeat(64), resume: "a".repeat(64), coverLetter: "b".repeat(64) };
+    expect(() => assertApprovedPacket(approved, good)).not.toThrow();
+    expect(() => assertApprovedPacket(approved, { ...good, packet: "d".repeat(64) })).toThrow(/packet/);
+    expect(() => assertApprovedPacket(approved, { ...good, resume: "d".repeat(64) })).toThrow(/resume/);
+    expect(() => assertApprovedPacket(approved, { ...good, coverLetter: "d".repeat(64) })).toThrow(/cover letter/);
+  });
+
   it("discovers and enforces Greenhouse job-specific required fields before submit", async () => {
     const fetcher = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ questions: [{ required: true, fields: [{ name: "question_1" }] }] }), { status: 200 })).mockResolvedValueOnce(new Response("{}", { status: 200 }));
     expect(await greenhouseRequiredFields("board", "1", fetcher)).toContain("question_1");
     const receipt = issueSubmissionApproval(preview("greenhouse"), secret);
     const missingFetcher = vi.fn().mockResolvedValue(new Response(JSON.stringify({ questions: [{ required: true, fields: [{ name: "question_1" }] }] }), { status: 200 }));
-    await expect(submitGreenhouse({ boardToken: "board", jobId: "1", apiKey: "server-secret", fields: { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" }, receipt, approvalSecret: secret }, missingFetcher)).rejects.toThrow(/question_1/);
+    await expect(submitGreenhouse({ apiKey: "server-secret", receipt, approvalSecret: secret }, missingFetcher)).rejects.toThrow(/question_1/);
     expect(missingFetcher).toHaveBeenCalledTimes(1);
   });
+
   it("retries rate-limited Greenhouse submission without exposing its server credential", async () => {
-    const fetcher = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ questions: [] }), { status: 200 })).mockResolvedValueOnce(new Response("rate", { status: 429, headers: { "retry-after": "0.001" } })).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ questions: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response("rate", { status: 429, headers: { "retry-after": "0.001" } }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
     const receipt = issueSubmissionApproval(preview("greenhouse"), secret);
-    expect((await submitGreenhouse({ boardToken: "board", jobId: "1", apiKey: "server-secret", fields: { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" }, receipt, approvalSecret: secret }, fetcher)).accepted).toBe(true);
+    expect((await submitGreenhouse({ apiKey: "server-secret", receipt, approvalSecret: secret }, fetcher)).accepted).toBe(true);
     expect(JSON.stringify(fetcher.mock.calls)).not.toContain("server-secret");
     expect((fetcher.mock.calls[1][1] as RequestInit).headers).toHaveProperty("authorization");
   });
-  it("requires employer-provided Lever required-field configuration", async () => {
+
+  it("keeps the Lever credential out of the request URL", async () => {
+    // Regression: the key was interpolated as ?key=..., so it landed in
+    // provider access logs, proxy logs, and any telemetry recording URLs.
     const receipt = issueSubmissionApproval(preview("lever"), secret);
-    await expect(submitLever({ site: "site", postingId: "post", apiKey: "key", requiredFields: [], fields: {}, receipt, approvalSecret: secret }, vi.fn())).rejects.toThrow(/Employer-provided/);
+    const fetcher = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    await submitLever({ apiKey: "lever-secret", receipt, approvalSecret: secret }, fetcher);
+    expect(fetcher.mock.calls[0][0]).toBe("https://api.lever.co/v0/postings/approved-site/222");
+    expect(String(fetcher.mock.calls[0][0])).not.toContain("lever-secret");
+    expect((fetcher.mock.calls[0][1] as RequestInit).headers).toHaveProperty("authorization");
   });
+
+  it("requires employer-provided Lever required-field configuration", () => {
+    const withoutRequired = { ...preview("lever"), target: { ...targets.lever, requiredFields: [] } } as unknown as SubmissionPreview;
+    expect(() => issueSubmissionApproval(withoutRequired, secret)).toThrow();
+  });
+
   it("creates a Gmail draft but never sends it", async () => {
     const fetcher = vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: "draft-1" }), { status: 200 }));
-    const result = await createGmailDraft({ accessToken: "token", rawMessage: "To: jobs@example.com\r\nSubject: Application\r\n\r\nHello", receipt: issueSubmissionApproval(preview("gmail"), secret), approvalSecret: secret }, fetcher);
-    expect(result).toMatchObject({ draftId: "draft-1", sent: false }); expect(fetcher.mock.calls[0][0]).toContain("/drafts"); expect(fetcher.mock.calls[0][0]).not.toContain("send");
+    const result = await createGmailDraft({ accessToken: "token", receipt: issueSubmissionApproval(preview("gmail"), secret), approvalSecret: secret }, fetcher);
+    expect(result).toMatchObject({ draftId: "draft-1", sent: false });
+    expect(fetcher.mock.calls[0][0]).toContain("/drafts");
+    expect(fetcher.mock.calls[0][0]).not.toContain("send");
+  });
+
+  it("refuses a receipt aimed at a different provider", async () => {
+    const receipt = issueSubmissionApproval(preview("lever"), secret);
+    await expect(submitGreenhouse({ apiKey: "k", receipt, approvalSecret: secret }, vi.fn())).rejects.toThrow(/provider mismatch/i);
   });
 });

--- a/lib/submission-connectors.test.ts
+++ b/lib/submission-connectors.test.ts
@@ -9,12 +9,14 @@ const targets: Record<SubmissionPreview["provider"], SubmissionTarget> = {
   gmail: { provider: "gmail", rawMessage: "To: jobs@example.com\r\nSubject: Application\r\n\r\nHello" },
 };
 
+const FIELDS = { first_name: "Ada", last_name: "Lovelace", name: "Ada Lovelace", email: "ada@example.com", resume_text: "APPROVED RESUME" };
+
 const preview = (provider: "greenhouse" | "lever" | "gmail"): SubmissionPreview => ({
   applicationId: "app-1", provider, company: "Acme", role: "Engineer",
   destination: submissionDestination(targets[provider]), packetVersion: 2,
   resumeChecksum: "a".repeat(64), coverLetterChecksum: "b".repeat(64), packetChecksum: "c".repeat(64),
-  personalDataCategories: ["email"],
-  fields: { first_name: "Ada", last_name: "Lovelace", name: "Ada Lovelace", email: "ada@example.com", resume_text: "APPROVED RESUME" },
+  personalDataCategories: outgoingDataCategories(FIELDS, targets[provider]),
+  fields: { ...FIELDS },
   createdAt: "2026-01-01T00:00:00.000Z", target: structuredClone(targets[provider]),
 });
 
@@ -121,10 +123,37 @@ describe("authorized submission connectors", () => {
     expect(() => issueSubmissionApproval(over, secret)).toThrow(/personal-data categories/);
   });
 
-  it("derives personal-data categories from the fields actually being sent", () => {
-    expect(outgoingDataCategories({ email: "ada@example.com" })).toEqual(["email"]);
-    expect(outgoingDataCategories({ a: "ssn 555-00-1234", b: "ada@example.com" }).sort()).toEqual(["email", "government identifier"]);
-    expect(outgoingDataCategories({ name: "Ada Lovelace" })).toEqual([]);
+  it("derives personal-data categories from what a field IS, not only what it matches", () => {
+    // Regression: derivation was regex-only, so a plain legal name, a résumé,
+    // and a cover letter reported ZERO categories while being transmitted — the
+    // consent record said "no personal data" about the most personal payload
+    // the app sends.
+    expect(outgoingDataCategories({ name: "Ada Lovelace" })).toEqual(["name"]);
+    expect(outgoingDataCategories({ first_name: "Ada", last_name: "Lovelace" })).toEqual(["name"]);
+    expect(outgoingDataCategories({ resume_text: "Built systems at Acme." })).toEqual(["resume"]);
+    expect(outgoingDataCategories({ cover_letter: "Dear hiring manager." })).toEqual(["cover letter"]);
+    expect(outgoingDataCategories({ question_12345: "I have five years." })).toEqual(["written responses"]);
+    expect(outgoingDataCategories({ "Phone-Number": "n/a" })).toEqual(["phone"]);
+    expect(outgoingDataCategories({ city: "Austin" })).toEqual(["street address"]);
+  });
+
+  it("still detects identifiers hiding inside free text", () => {
+    expect(outgoingDataCategories({ q1: "reach me at ada@example.com" })).toEqual(["email", "written responses"]);
+    expect(outgoingDataCategories({ notes: "ssn 555-00-1234" })).toEqual(["government identifier", "written responses"]);
+  });
+
+  it("counts the Gmail message body, which is that provider's entire payload", () => {
+    expect(outgoingDataCategories({}, targets.gmail)).toEqual(["email", "message body"]);
+  });
+
+  it("declares an unrecognised field rather than silently omitting it", () => {
+    // Employers define arbitrary field names, so under-declaring is the failure
+    // mode to avoid: an unknown field still carries applicant-authored text.
+    expect(outgoingDataCategories({ tell_us_about_yourself: "I build systems." })).toEqual(["written responses"]);
+  });
+
+  it("ignores empty and non-string field values", () => {
+    expect(outgoingDataCategories({ name: "   ", resume_text: "", count: 3 })).toEqual([]);
   });
 
   it("discovers and enforces Greenhouse job-specific required fields before submit", async () => {

--- a/lib/submission-connectors.test.ts
+++ b/lib/submission-connectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { assertApprovedPacket, createGmailDraft, greenhouseRequiredFields, issueSubmissionApproval, submitGreenhouse, submitLever, verifySubmissionApproval, type SubmissionPreview, type SubmissionTarget } from "./submission-connectors";
+import { assertApprovedPacket, createGmailDraft, greenhouseRequiredFields, issueSubmissionApproval, outgoingDataCategories, submissionDestination, submitGreenhouse, submitLever, verifySubmissionApproval, type ApprovablePacket, type SubmissionPreview, type SubmissionTarget } from "./submission-connectors";
 
 const secret = "this-is-a-human-approval-secret";
 
@@ -11,7 +11,7 @@ const targets: Record<SubmissionPreview["provider"], SubmissionTarget> = {
 
 const preview = (provider: "greenhouse" | "lever" | "gmail"): SubmissionPreview => ({
   applicationId: "app-1", provider, company: "Acme", role: "Engineer",
-  destination: "https://example.com/apply", packetVersion: 2,
+  destination: submissionDestination(targets[provider]), packetVersion: 2,
   resumeChecksum: "a".repeat(64), coverLetterChecksum: "b".repeat(64), packetChecksum: "c".repeat(64),
   personalDataCategories: ["email"],
   fields: { first_name: "Ada", last_name: "Lovelace", name: "Ada Lovelace", email: "ada@example.com", resume_text: "APPROVED RESUME" },
@@ -84,13 +84,47 @@ describe("authorized submission connectors", () => {
     expect(() => issueSubmissionApproval(mismatched, secret)).toThrow();
   });
 
-  it("binds the exact frozen packet, résumé, and cover letter", () => {
+  it("binds the packet identity, version, employer, role, and content digests", () => {
     const approved = preview("greenhouse");
-    const good = { packet: "c".repeat(64), resume: "a".repeat(64), coverLetter: "b".repeat(64) };
-    expect(() => assertApprovedPacket(approved, good)).not.toThrow();
-    expect(() => assertApprovedPacket(approved, { ...good, packet: "d".repeat(64) })).toThrow(/packet/);
-    expect(() => assertApprovedPacket(approved, { ...good, resume: "d".repeat(64) })).toThrow(/resume/);
-    expect(() => assertApprovedPacket(approved, { ...good, coverLetter: "d".repeat(64) })).toThrow(/cover letter/);
+    const packet: ApprovablePacket = {
+      id: "app-1", version: 2,
+      checksums: { packet: "c".repeat(64), resume: "a".repeat(64), coverLetter: "b".repeat(64) },
+      jobSnapshot: { company: "Acme", title: "Engineer" },
+    };
+    expect(() => assertApprovedPacket(approved, packet)).not.toThrow();
+
+    const mutate = (patch: Partial<ApprovablePacket>) => ({ ...structuredClone(packet), ...patch });
+    expect(() => assertApprovedPacket(approved, mutate({ checksums: { ...packet.checksums, packet: "d".repeat(64) } }))).toThrow(/packet/);
+    expect(() => assertApprovedPacket(approved, mutate({ checksums: { ...packet.checksums, resume: "d".repeat(64) } }))).toThrow(/resume/);
+    expect(() => assertApprovedPacket(approved, mutate({ checksums: { ...packet.checksums, coverLetter: "d".repeat(64) } }))).toThrow(/cover letter/);
+    // A digest-identical packet from a different application, version, or
+    // employer must still be refused: the applicant approved a specific
+    // application for a specific employer and role, not just some bytes.
+    expect(() => assertApprovedPacket(approved, mutate({ id: "app-2" }))).toThrow(/application id/);
+    expect(() => assertApprovedPacket(approved, mutate({ version: 3 }))).toThrow(/packet version/);
+    expect(() => assertApprovedPacket(approved, mutate({ jobSnapshot: { company: "Other Corp", title: "Engineer" } }))).toThrow(/company/);
+    expect(() => assertApprovedPacket(approved, mutate({ jobSnapshot: { company: "Acme", title: "Manager" } }))).toThrow(/role/);
+  });
+
+  it("refuses a preview whose displayed destination is not where the target routes", () => {
+    // The applicant reads `destination`; the machine acts on `target`. Left
+    // independent, a preview could display an approved employer while the signed
+    // target routed somewhere else entirely.
+    const lying = { ...preview("greenhouse"), destination: "https://boards.greenhouse.io/trusted-employer/jobs/999" } as SubmissionPreview;
+    expect(() => issueSubmissionApproval(lying, secret)).toThrow(/Displayed destination must match/);
+  });
+
+  it("refuses a preview that under-declares the personal data it will send", () => {
+    const under = { ...preview("greenhouse"), personalDataCategories: [] } as SubmissionPreview;
+    expect(() => issueSubmissionApproval(under, secret)).toThrow(/personal-data categories/);
+    const over = { ...preview("greenhouse"), personalDataCategories: ["email", "government identifier"] } as SubmissionPreview;
+    expect(() => issueSubmissionApproval(over, secret)).toThrow(/personal-data categories/);
+  });
+
+  it("derives personal-data categories from the fields actually being sent", () => {
+    expect(outgoingDataCategories({ email: "ada@example.com" })).toEqual(["email"]);
+    expect(outgoingDataCategories({ a: "ssn 555-00-1234", b: "ada@example.com" }).sort()).toEqual(["email", "government identifier"]);
+    expect(outgoingDataCategories({ name: "Ada Lovelace" })).toEqual([]);
   });
 
   it("discovers and enforces Greenhouse job-specific required fields before submit", async () => {

--- a/lib/submission-connectors.ts
+++ b/lib/submission-connectors.ts
@@ -39,10 +39,59 @@ export function submissionDestination(target: SubmissionTarget): string {
   }
 }
 
-/** The personal-data categories actually present in the outgoing fields. */
-export function outgoingDataCategories(fields: Record<string, unknown>): string[] {
-  const text = Object.values(fields).filter((value) => typeof value === "string").join("\n");
-  return [...new Set(protectPii(text).matches.map((match) => match.kind))].sort();
+/**
+ * What a field *is*, independent of whether its value matches a pattern.
+ *
+ * Pattern matching alone is not a consent record: `name: "Ada Lovelace"`,
+ * a résumé, and a cover letter contain no email or SSN shape, so a regex-only
+ * derivation reported zero categories while transmitting the applicant's legal
+ * name and full employment history. Field semantics are the primary signal;
+ * `protectPii` then adds identifiers that appear inside free text.
+ */
+const FIELD_CATEGORIES: ReadonlyArray<{ category: string; match: RegExp }> = [
+  { category: "name", match: /^(?:name|first_name|last_name|middle_name|full_name|preferred_name|legal_name)$/u },
+  { category: "email", match: /^(?:email|email_address)$/u },
+  { category: "phone", match: /^(?:phone|phone_number|telephone|mobile)$/u },
+  { category: "street address", match: /^(?:address|street_address|address_line_?\d*|city|region|postal_code|zip)$/u },
+  { category: "web profile", match: /^(?:website|linkedin|github|portfolio|url)$/u },
+  { category: "resume", match: /^(?:resume|resume_text|resume_content|cv|cv_text)$/u },
+  { category: "cover letter", match: /^(?:cover_letter|cover_letter_text|coverletter|letter)$/u },
+  { category: "written responses", match: /^(?:question_.*|screening.*|answers?)$/u },
+  { category: "message body", match: /^(?:raw_?message|message|body)$/u },
+];
+
+const normaliseFieldName = (key: string) => key.trim().toLowerCase().replace(/[\s-]+/gu, "_");
+
+/**
+ * The personal-data categories actually leaving the app for a submission.
+ *
+ * Covers both the provider fields and, for Gmail, the drafted message body —
+ * which is the entire payload for that provider and was previously not
+ * considered at all.
+ */
+export function outgoingDataCategories(fields: Record<string, unknown>, target?: SubmissionTarget): string[] {
+  const categories = new Set<string>();
+  const freeText: string[] = [];
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (typeof value !== "string" || value.trim() === "") continue;
+    freeText.push(value);
+    const name = normaliseFieldName(key);
+    const matched = FIELD_CATEGORIES.filter(({ match }) => match.test(name));
+    for (const { category } of matched) categories.add(category);
+    // Employers define arbitrary field names, so a fixed list can never be
+    // exhaustive. An unrecognised field still carries applicant-authored text,
+    // and under-declaring a disclosure is worse than over-declaring one.
+    if (matched.length === 0) categories.add("written responses");
+  }
+
+  if (target?.provider === "gmail") {
+    categories.add("message body");
+    freeText.push(target.rawMessage);
+  }
+
+  for (const match of protectPii(freeText.join("\n")).matches) categories.add(match.kind);
+  return [...categories].sort();
 }
 
 const SHA256_HEX = /^[a-f0-9]{64}$/;
@@ -68,7 +117,7 @@ export const SubmissionPreviewSchema = z.strictObject({
   }
   // Declared personal-data categories must be the ones actually being sent, so
   // the disclosure the applicant consents to is the disclosure that happens.
-  const actual = outgoingDataCategories(value.fields);
+  const actual = outgoingDataCategories(value.fields, value.target);
   const declared = [...new Set(value.personalDataCategories)].sort();
   if (declared.join("|") !== actual.join("|")) {
     context.addIssue({ code: "custom", message: `Declared personal-data categories must match the outgoing fields (${actual.join(", ") || "none"}).` });

--- a/lib/submission-connectors.ts
+++ b/lib/submission-connectors.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 import { canonicalJson } from "./canonical-json";
+import { protectPii } from "./pii";
 
 export const SubmissionProviderSchema = z.enum(["greenhouse", "lever", "gmail"]);
 
@@ -21,6 +22,29 @@ export const SubmissionTargetSchema = z.discriminatedUnion("provider", [
 ]);
 export type SubmissionTarget = z.infer<typeof SubmissionTargetSchema>;
 
+/**
+ * The canonical human-facing destination for a signed target.
+ *
+ * `destination` is what the applicant reads; `target` is what the machine acts
+ * on. Left independent, a preview could display an approved employer while the
+ * signed target routed somewhere else entirely — the human approves one thing
+ * and the request goes to another. Deriving it makes that divergence
+ * unrepresentable.
+ */
+export function submissionDestination(target: SubmissionTarget): string {
+  switch (target.provider) {
+    case "greenhouse": return `https://boards.greenhouse.io/${target.boardToken}/jobs/${target.jobId}`;
+    case "lever": return `https://jobs.lever.co/${target.site}/${target.postingId}`;
+    case "gmail": return "https://mail.google.com/mail/u/0/#drafts";
+  }
+}
+
+/** The personal-data categories actually present in the outgoing fields. */
+export function outgoingDataCategories(fields: Record<string, unknown>): string[] {
+  const text = Object.values(fields).filter((value) => typeof value === "string").join("\n");
+  return [...new Set(protectPii(text).matches.map((match) => match.kind))].sort();
+}
+
 const SHA256_HEX = /^[a-f0-9]{64}$/;
 
 export const SubmissionPreviewSchema = z.strictObject({
@@ -35,6 +59,19 @@ export const SubmissionPreviewSchema = z.strictObject({
 }).superRefine((value, context) => {
   if (value.target.provider !== value.provider) {
     context.addIssue({ code: "custom", message: "Approved target provider must match the preview provider." });
+    return;
+  }
+  // The displayed destination must be the one the signed target routes to.
+  const expected = submissionDestination(value.target);
+  if (value.destination !== expected) {
+    context.addIssue({ code: "custom", message: `Displayed destination must match the signed target (${expected}).` });
+  }
+  // Declared personal-data categories must be the ones actually being sent, so
+  // the disclosure the applicant consents to is the disclosure that happens.
+  const actual = outgoingDataCategories(value.fields);
+  const declared = [...new Set(value.personalDataCategories)].sort();
+  if (declared.join("|") !== actual.join("|")) {
+    context.addIssue({ code: "custom", message: `Declared personal-data categories must match the outgoing fields (${actual.join(", ") || "none"}).` });
   }
 });
 export type SubmissionPreview = z.infer<typeof SubmissionPreviewSchema>;
@@ -88,16 +125,34 @@ export function verifySubmissionApproval(receipt: unknown, secret: string, now =
 }
 
 /**
- * Throws unless the packet presented for transmission is the exact packet the
- * applicant approved. Callers must additionally run `verifyApplicationPacket`
- * so a self-consistent but forged packet cannot satisfy this by simply
- * carrying matching checksums of its own tampered content.
+ * The subset of an application packet a submission must agree with. Structural
+ * so this module stays independent of the applications module.
  */
-export function assertApprovedPacket(preview: SubmissionPreview, checksums: { packet: string; resume: string; coverLetter: string }) {
+export interface ApprovablePacket {
+  id: string;
+  version: number;
+  checksums: { packet: string; resume: string; coverLetter: string };
+  jobSnapshot: { company: string; title: string };
+}
+
+/**
+ * Throws unless the packet presented for transmission is the exact packet the
+ * applicant approved — including the identity and the employer name and role
+ * they read on screen, not only the content digests.
+ *
+ * Callers must additionally run `verifyApplicationPacket` so a self-consistent
+ * but forged packet cannot satisfy this by carrying matching checksums of its
+ * own tampered content.
+ */
+export function assertApprovedPacket(preview: SubmissionPreview, packet: ApprovablePacket) {
   const mismatched = [
-    preview.packetChecksum !== checksums.packet && "packet",
-    preview.resumeChecksum !== checksums.resume && "resume",
-    preview.coverLetterChecksum !== checksums.coverLetter && "cover letter",
+    preview.packetChecksum !== packet.checksums.packet && "packet",
+    preview.resumeChecksum !== packet.checksums.resume && "resume",
+    preview.coverLetterChecksum !== packet.checksums.coverLetter && "cover letter",
+    preview.applicationId !== packet.id && "application id",
+    preview.packetVersion !== packet.version && "packet version",
+    preview.company !== packet.jobSnapshot.company && "company",
+    preview.role !== packet.jobSnapshot.title && "role",
   ].filter(Boolean);
   if (mismatched.length) throw new Error(`Submission packet does not match the approved packet (${mismatched.join(", ")}).`);
 }

--- a/lib/submission-connectors.ts
+++ b/lib/submission-connectors.ts
@@ -1,27 +1,105 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
+import { canonicalJson } from "./canonical-json";
 
 export const SubmissionProviderSchema = z.enum(["greenhouse", "lever", "gmail"]);
+
+const PROVIDER_TOKEN = /^[A-Za-z0-9_-]{1,100}$/;
+
+/**
+ * Where the submission goes and what routes it.
+ *
+ * This used to be read from the unsigned request body, so a receipt approved
+ * for one board could be replayed to submit to a different board and job.
+ * Routing is part of what the applicant approves, so it lives inside the
+ * signed preview.
+ */
+export const SubmissionTargetSchema = z.discriminatedUnion("provider", [
+  z.strictObject({ provider: z.literal("greenhouse"), boardToken: z.string().regex(PROVIDER_TOKEN), jobId: z.string().regex(PROVIDER_TOKEN) }),
+  z.strictObject({ provider: z.literal("lever"), site: z.string().regex(PROVIDER_TOKEN), postingId: z.string().regex(PROVIDER_TOKEN), requiredFields: z.array(z.string().min(1)).min(1) }),
+  z.strictObject({ provider: z.literal("gmail"), rawMessage: z.string().min(1).max(5_000_000) }),
+]);
+export type SubmissionTarget = z.infer<typeof SubmissionTargetSchema>;
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
 export const SubmissionPreviewSchema = z.strictObject({
   applicationId: z.string().min(1), provider: SubmissionProviderSchema, company: z.string().min(1), role: z.string().min(1),
-  destination: z.string().url(), packetVersion: z.number().int().positive(), resumeChecksum: z.string().regex(/^[a-f0-9]{64}$/),
-  coverLetterChecksum: z.string().regex(/^[a-f0-9]{64}$/), personalDataCategories: z.array(z.string()),
+  destination: z.string().url(), packetVersion: z.number().int().positive(), resumeChecksum: z.string().regex(SHA256_HEX),
+  coverLetterChecksum: z.string().regex(SHA256_HEX),
+  /** Binds the exact frozen packet the applicant reviewed. */
+  packetChecksum: z.string().regex(SHA256_HEX),
+  personalDataCategories: z.array(z.string()),
   fields: z.record(z.string(), z.unknown()), createdAt: z.string().datetime(),
+  target: SubmissionTargetSchema,
+}).superRefine((value, context) => {
+  if (value.target.provider !== value.provider) {
+    context.addIssue({ code: "custom", message: "Approved target provider must match the preview provider." });
+  }
 });
 export type SubmissionPreview = z.infer<typeof SubmissionPreviewSchema>;
 
-export interface ApprovalReceipt { preview: SubmissionPreview; approvedAt: string; expiresAt: string; nonce: string; signature: string }
+const APPROVAL_TTL_MS = 10 * 60_000;
+
+export const ApprovalReceiptSchema = z.strictObject({
+  preview: SubmissionPreviewSchema,
+  approvedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  nonce: z.string().min(8).max(200),
+  signature: z.string().min(1),
+});
+export type ApprovalReceipt = z.infer<typeof ApprovalReceiptSchema>;
+
+const mac = (unsigned: unknown, secret: string) => createHmac("sha256", secret).update(canonicalJson(unsigned)).digest();
+
 export function issueSubmissionApproval(preview: SubmissionPreview, secret: string, now = new Date()): ApprovalReceipt {
   if (secret.length < 24) throw new Error("Submission approval secret must be at least 24 characters.");
-  const expires = new Date(now.getTime() + 10 * 60_000);
-  const unsigned = { preview: SubmissionPreviewSchema.parse(preview), approvedAt: now.toISOString(), expiresAt: expires.toISOString(), nonce: randomUUID() };
-  return { ...unsigned, signature: createHmac("sha256", secret).update(JSON.stringify(unsigned)).digest("base64url") };
+  const unsigned = {
+    preview: SubmissionPreviewSchema.parse(preview),
+    approvedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + APPROVAL_TTL_MS).toISOString(),
+    nonce: randomUUID(),
+  };
+  return { ...unsigned, signature: mac(unsigned, secret).toString("base64url") };
 }
-export function verifySubmissionApproval(receipt: ApprovalReceipt, secret: string, now = new Date()): SubmissionPreview {
-  const { signature, ...unsigned } = receipt; const expected = createHmac("sha256", secret).update(JSON.stringify(unsigned)).digest();
+
+/**
+ * Returns the approved preview, or throws. Everything transmitted downstream
+ * must be read from this return value, never from the caller's request body.
+ */
+export function verifySubmissionApproval(receipt: unknown, secret: string, now = new Date()): SubmissionPreview {
+  // Parse before comparing: a malformed `expiresAt` previously reached
+  // `new Date(...)`, produced NaN, and `NaN <= now` is false — so a receipt
+  // with `expiresAt: "not-a-date"` never expired.
+  const parsed = ApprovalReceiptSchema.safeParse(receipt);
+  if (!parsed.success) throw new Error("Submission approval is invalid or expired.");
+  const { signature, ...unsigned } = parsed.data;
+  const expected = mac(unsigned, secret);
   const actual = Buffer.from(signature, "base64url");
-  if (actual.length !== expected.length || !timingSafeEqual(actual, expected) || new Date(receipt.expiresAt) <= now) throw new Error("Submission approval is invalid or expired.");
-  return SubmissionPreviewSchema.parse(receipt.preview);
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) throw new Error("Submission approval is invalid or expired.");
+
+  const expiresAt = Date.parse(parsed.data.expiresAt);
+  const approvedAt = Date.parse(parsed.data.approvedAt);
+  if (!Number.isFinite(expiresAt) || !Number.isFinite(approvedAt)) throw new Error("Submission approval is invalid or expired.");
+  if (expiresAt <= now.getTime()) throw new Error("Submission approval is invalid or expired.");
+  // Holding the signing key must not buy a longer window than the policy.
+  if (expiresAt - approvedAt > APPROVAL_TTL_MS) throw new Error("Submission approval is invalid or expired.");
+  return parsed.data.preview;
+}
+
+/**
+ * Throws unless the packet presented for transmission is the exact packet the
+ * applicant approved. Callers must additionally run `verifyApplicationPacket`
+ * so a self-consistent but forged packet cannot satisfy this by simply
+ * carrying matching checksums of its own tampered content.
+ */
+export function assertApprovedPacket(preview: SubmissionPreview, checksums: { packet: string; resume: string; coverLetter: string }) {
+  const mismatched = [
+    preview.packetChecksum !== checksums.packet && "packet",
+    preview.resumeChecksum !== checksums.resume && "resume",
+    preview.coverLetterChecksum !== checksums.coverLetter && "cover letter",
+  ].filter(Boolean);
+  if (mismatched.length) throw new Error(`Submission packet does not match the approved packet (${mismatched.join(", ")}).`);
 }
 
 type Fetcher = typeof fetch;
@@ -50,26 +128,46 @@ function validateFields(fields: Record<string, unknown>, required: readonly stri
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(String(fields.email))) throw new Error("email must be valid.");
 }
 
-export async function submitGreenhouse(input: { boardToken: string; jobId: string; apiKey: string; fields: Record<string, unknown>; receipt: ApprovalReceipt; approvalSecret: string }, fetcher: Fetcher = fetch) {
-  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret); if (preview.provider !== "greenhouse") throw new Error("Approval provider mismatch.");
-  const required = await greenhouseRequiredFields(input.boardToken, input.jobId, fetcher); validateFields(input.fields, required);
-  const response = await retryRequest(`https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(input.boardToken)}/jobs/${encodeURIComponent(input.jobId)}`,
-    { method: "POST", headers: { authorization: `Basic ${Buffer.from(`${input.apiKey}:`).toString("base64")}`, "content-type": "application/json" }, body: JSON.stringify(input.fields) }, fetcher);
+/**
+ * Every connector below takes only a receipt plus deployment credentials.
+ *
+ * There is deliberately no `fields`, `boardToken`, `jobId`, `site`,
+ * `postingId`, or `rawMessage` parameter: routing and content are read from the
+ * verified preview, so a caller cannot substitute anything the applicant did
+ * not approve. That substitution was the original defect — the receipt verified
+ * while the request body supplied a different board and a different résumé.
+ */
+export async function submitGreenhouse(input: { apiKey: string; receipt: unknown; approvalSecret: string }, fetcher: Fetcher = fetch) {
+  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret);
+  if (preview.target.provider !== "greenhouse") throw new Error("Approval provider mismatch.");
+  const { boardToken, jobId } = preview.target;
+  const required = await greenhouseRequiredFields(boardToken, jobId, fetcher);
+  validateFields(preview.fields, required);
+  const response = await retryRequest(`https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(boardToken)}/jobs/${encodeURIComponent(jobId)}`,
+    { method: "POST", headers: { authorization: `Basic ${Buffer.from(`${input.apiKey}:`).toString("base64")}`, "content-type": "application/json" }, body: JSON.stringify(preview.fields) }, fetcher);
   return { provider: "greenhouse" as const, accepted: true, status: response.status, applicationId: preview.applicationId };
 }
 
-export async function submitLever(input: { site: string; postingId: string; apiKey: string; requiredFields: string[]; fields: Record<string, unknown>; receipt: ApprovalReceipt; approvalSecret: string }, fetcher: Fetcher = fetch) {
-  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret); if (preview.provider !== "lever") throw new Error("Approval provider mismatch.");
-  if (!input.requiredFields.length) throw new Error("Employer-provided Lever required-field configuration is required.");
-  validateFields(input.fields, [...new Set(["name", "email", ...input.requiredFields])]);
-  const url = `https://api.lever.co/v0/postings/${encodeURIComponent(input.site)}/${encodeURIComponent(input.postingId)}?key=${encodeURIComponent(input.apiKey)}`;
-  const response = await retryRequest(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input.fields) }, fetcher);
+export async function submitLever(input: { apiKey: string; receipt: unknown; approvalSecret: string }, fetcher: Fetcher = fetch) {
+  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret);
+  if (preview.target.provider !== "lever") throw new Error("Approval provider mismatch.");
+  const { site, postingId, requiredFields } = preview.target;
+  validateFields(preview.fields, [...new Set(["name", "email", ...requiredFields])]);
+  // The key stays in a header: a query-string credential lands in provider
+  // access logs, proxy logs, and any telemetry that records request URLs.
+  const url = `https://api.lever.co/v0/postings/${encodeURIComponent(site)}/${encodeURIComponent(postingId)}`;
+  const response = await retryRequest(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Basic ${Buffer.from(`${input.apiKey}:`).toString("base64")}` },
+    body: JSON.stringify(preview.fields),
+  }, fetcher);
   return { provider: "lever" as const, accepted: true, status: response.status, applicationId: preview.applicationId };
 }
 
-export async function createGmailDraft(input: { accessToken: string; rawMessage: string; receipt: ApprovalReceipt; approvalSecret: string }, fetcher: Fetcher = fetch) {
-  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret); if (preview.provider !== "gmail") throw new Error("Approval provider mismatch.");
-  const raw = Buffer.from(input.rawMessage, "utf8").toString("base64url");
+export async function createGmailDraft(input: { accessToken: string; receipt: unknown; approvalSecret: string }, fetcher: Fetcher = fetch) {
+  const preview = verifySubmissionApproval(input.receipt, input.approvalSecret);
+  if (preview.target.provider !== "gmail") throw new Error("Approval provider mismatch.");
+  const raw = Buffer.from(preview.target.rawMessage, "utf8").toString("base64url");
   const response = await retryRequest("https://gmail.googleapis.com/gmail/v1/users/me/drafts", { method: "POST", headers: { authorization: `Bearer ${input.accessToken}`, "content-type": "application/json" }, body: JSON.stringify({ message: { raw } }) }, fetcher);
   const body = await response.json() as { id?: string }; if (!body.id) throw new Error("Gmail did not return a draft identifier.");
   return { provider: "gmail" as const, draftId: body.id, sent: false, applicationId: preview.applicationId };

--- a/lib/submission-ledger.test.ts
+++ b/lib/submission-ledger.test.ts
@@ -5,18 +5,42 @@ import path from "node:path";
 import { consumeSubmissionApproval } from "./submission-ledger";
 
 let root = "";
-beforeEach(async () => { root = await mkdtemp(path.join(tmpdir(), "submission-ledger-")); process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER = path.join(root, "used.json"); });
+beforeEach(async () => { root = await mkdtemp(path.join(tmpdir(), "submission-ledger-")); process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER = path.join(root, "used.jsonl"); });
 afterEach(async () => { delete process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER; await rm(root, { recursive: true, force: true }); });
+
+const readLines = async () =>
+  (await readFile(process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER!, "utf8")).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+
 describe("submission approval consumption", () => {
-  it("durably rejects approval receipt replay", async () => {
+  it("durably rejects approval receipt replay and records the use", async () => {
     const use = { nonce: "nonce-1", applicationId: "app-1", provider: "greenhouse", consumedAt: "2026-01-01T00:00:00Z" };
     await consumeSubmissionApproval(use);
     await expect(consumeSubmissionApproval(use)).rejects.toThrow(/already been consumed/);
-    expect(JSON.parse(await readFile(process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER!, "utf8")).consumed).toEqual([use]);
+    expect(await readLines()).toEqual([use]);
   });
-  it("serializes concurrent attempts so exactly one consumes a nonce", async () => {
+
+  it("lets exactly one of many concurrent attempts consume a nonce", async () => {
     const use = { nonce: "same", applicationId: "app-1", provider: "lever", consumedAt: "2026-01-01T00:00:00Z" };
-    const outcomes = await Promise.allSettled([consumeSubmissionApproval(use), consumeSubmissionApproval(use)]);
-    expect(outcomes.map((item) => item.status).sort()).toEqual(["fulfilled", "rejected"]);
+    const outcomes = await Promise.allSettled(Array.from({ length: 6 }, () => consumeSubmissionApproval(use)));
+    expect(outcomes.filter((item) => item.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((item) => item.status === "rejected")).toHaveLength(5);
+    expect(await readLines()).toHaveLength(1);
+  });
+
+  it("appends rather than rewriting, so concurrent records cannot be lost", async () => {
+    // Regression: the ledger read the whole JSON file, pushed, and rewrote it.
+    // Under concurrency the last writer won and earlier records vanished.
+    // Cross-process atomicity of the claim itself is covered in nonce-store.test.ts.
+    await Promise.all(["a", "b", "c", "d", "e"].map((nonce) =>
+      consumeSubmissionApproval({ nonce, applicationId: `app-${nonce}`, provider: "greenhouse", consumedAt: "2026-01-01T00:00:00Z" })));
+    expect((await readLines()).map((entry) => entry.nonce).sort()).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("fails closed when the ledger path is unset or relative", async () => {
+    const use = { nonce: "n", applicationId: "app", provider: "gmail", consumedAt: "2026-01-01T00:00:00Z" };
+    delete process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER;
+    await expect(consumeSubmissionApproval(use)).rejects.toThrow(/must be configured/);
+    process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER = "relative/used.jsonl";
+    await expect(consumeSubmissionApproval(use)).rejects.toThrow(/absolute path/);
   });
 });

--- a/lib/submission-ledger.ts
+++ b/lib/submission-ledger.ts
@@ -1,16 +1,40 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { createDurableNonceStore, type NonceStore } from "./nonce-store";
 
 type ReceiptUse = { nonce: string; applicationId: string; provider: string; consumedAt: string };
-type Ledger = { version: 1; consumed: ReceiptUse[] };
-let queue: Promise<void> = Promise.resolve();
-function target() { const value = process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER?.trim(); if (!value) throw new Error("RESUME_FOUNDRY_SUBMISSION_LEDGER must be configured."); return value; }
-async function load(): Promise<Ledger> { try { return JSON.parse(await readFile(target(), "utf8")) as Ledger; } catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, consumed: [] }; throw error; } }
-export async function consumeSubmissionApproval(use: ReceiptUse) {
-  const prior = queue; let release!: () => void; queue = new Promise<void>((resolve) => { release = resolve; }); await prior;
-  try {
-    const ledger = await load(); if (ledger.consumed.some((entry) => entry.nonce === use.nonce)) throw new Error("Submission approval has already been consumed.");
-    ledger.consumed.push(use); const file = target(); await mkdir(path.dirname(file), { recursive: true }); const temp = `${file}.${process.pid}.tmp`;
-    await writeFile(temp, JSON.stringify(ledger, null, 2), { encoding: "utf8", mode: 0o600 }); await rename(temp, file);
-  } finally { release(); }
+
+function ledgerPath() {
+  const value = process.env.RESUME_FOUNDRY_SUBMISSION_LEDGER?.trim();
+  if (!value) throw new Error("RESUME_FOUNDRY_SUBMISSION_LEDGER must be configured.");
+  if (!path.isAbsolute(value)) throw new Error("RESUME_FOUNDRY_SUBMISSION_LEDGER must be an absolute path on durable storage.");
+  return value;
+}
+
+/**
+ * Nonce markers live beside the audit log, on whichever durable volume the
+ * operator already chose, so replay protection needs no extra configuration.
+ */
+const nonceDirectoryFor = (ledger: string) => `${ledger}.nonces`;
+
+/**
+ * Claims a submission approval exactly once, then records the use.
+ *
+ * The previous implementation serialised a whole-file read-modify-write behind
+ * a module-scoped promise queue. That serialises only within one Node process,
+ * so two module instances — or two Next.js workers — each read `consumed: []`,
+ * both proceeded to transmit, and one write was lost: a duplicate application
+ * with no trace of the second. The claim is now a single atomic O_EXCL file
+ * creation, and the audit is an append rather than a rewrite, so concurrent
+ * records cannot overwrite one another either.
+ */
+export async function consumeSubmissionApproval(use: ReceiptUse, store?: NonceStore) {
+  const ledger = ledgerPath();
+  const nonces = store ?? createDurableNonceStore({ directory: nonceDirectoryFor(ledger) });
+
+  // Claim first: if this loses, nothing has been transmitted and nothing is recorded.
+  if (!nonces.consume(use.nonce)) throw new Error("Submission approval has already been consumed.");
+
+  await mkdir(path.dirname(ledger), { recursive: true });
+  await appendFile(ledger, `${JSON.stringify(use)}\n`, { encoding: "utf8", mode: 0o600 });
 }

--- a/lib/testdata/agent-operation-probe.ts
+++ b/lib/testdata/agent-operation-probe.ts
@@ -1,0 +1,16 @@
+/**
+ * Child-process probe for the cross-process agent-store race test.
+ *
+ * Deliberately a separate OS process: the defect was a module-scoped promise
+ * queue that serialises only inside one Node process, so a same-process test
+ * cannot detect it.
+ *
+ * Usage: node --experimental-strip-types agent-operation-probe.ts <storePath> <json-request>
+ * Prints the JSON result.
+ */
+import { executeAgentOperation, type AgentRequest } from "../agent-service.ts";
+
+const [storePath, payload] = process.argv.slice(2);
+process.env.RESUME_FOUNDRY_AGENT_STORE = storePath;
+const result = await executeAgentOperation(JSON.parse(payload) as AgentRequest);
+process.stdout.write(JSON.stringify(result));

--- a/lib/testdata/consume-nonce-probe.ts
+++ b/lib/testdata/consume-nonce-probe.ts
@@ -1,0 +1,15 @@
+/**
+ * Child-process probe for the cross-process nonce test.
+ *
+ * Deliberately a separate OS process: the defect being guarded against was a
+ * module-scoped promise queue that serialises only inside one Node process, so
+ * a same-process test cannot detect it.
+ *
+ * Usage: node --experimental-strip-types consume-nonce-probe.ts <dir> <nonce>
+ * Prints exactly "WON" or "LOST".
+ */
+import { createDurableNonceStore } from "../nonce-store.ts";
+
+const [directory, nonce] = process.argv.slice(2);
+const store = createDurableNonceStore({ directory });
+process.stdout.write(store.consume(nonce) ? "WON" : "LOST");

--- a/public/AGENT_ACCESS.md
+++ b/public/AGENT_ACCESS.md
@@ -1,6 +1,6 @@
 # Resume Foundry Agent Access
 
-Resume Foundry is a local-first résumé-tailoring and job-search reference app. Its agent API requires a bearer token and routes every operation through the same server-side permission/audit engine used by MCP. It is still not an internet-ready multi-user deployment.
+Resume Foundry is a local-first résumé-tailoring and job-search reference app. The HTTP agent API requires a bearer token. Both interfaces route calls through the same server-side `executeAgentOperation` permission/audit engine, but they do **not** expose the same operations, and the stdio MCP interface is **not** bearer-authenticated — see "Interface differences". It is still not an internet-ready multi-user deployment.
 
 ## Discovery
 
@@ -14,9 +14,24 @@ Resume Foundry is a local-first résumé-tailoring and job-search reference app.
 - `POST /api/tailor` with `{ resume, jobDescription, jobTitle?, company?, emphasis? }` streams NDJSON events: `progress`, `result`, or `error`.
 - `POST /api/agent/{operation}` exposes the fourteen operations listed in OpenAPI. Send `Authorization: Bearer $RESUME_FOUNDRY_AGENT_API_TOKEN`.
 - `GET /api/agent/audit` returns the persisted allowed/denied audit trail without raw request data.
-- `npm run mcp` launches the stdio MCP server. It calls the identical `executeAgentOperation` policy boundary.
+- `npm run mcp` launches the stdio MCP server. It calls the same `executeAgentOperation` policy boundary but exposes only the subset of operations listed under "Interface differences", and requires `RESUME_FOUNDRY_MCP_ENABLED=true`.
 
-Set `RESUME_FOUNDRY_AGENT_STORE` to an absolute durable, access-controlled path before using either agent interface. The service fails closed rather than silently writing to an ephemeral deployment directory.
+Set `RESUME_FOUNDRY_AGENT_STORE` to an absolute durable, access-controlled path before using either agent interface. A missing or relative path fails closed rather than silently writing to an ephemeral deployment directory.
+
+Note on file permissions: the durable store holds raw packet content and is written with mode `0o600`. POSIX modes are not enforced on Windows, so on a Windows host the store is readable by other local users. Place it on a volume with appropriate ACLs.
+
+## Interface differences
+
+A stdio server has no bearer token to verify — its real trust boundary is the local user who launched the process. Earlier revisions of this document claimed bearer authentication for MCP; that was untrue. Rather than fake a check whose secret the launcher already holds, the stdio surface requires an explicit `RESUME_FOUNDRY_MCP_ENABLED=true` opt-in and withholds the operations that need a human in the loop.
+
+| | HTTP `/api/agent/*` | stdio MCP |
+|---|---|---|
+| Authentication | `Authorization: Bearer $RESUME_FOUNDRY_AGENT_API_TOKEN` | none — local process/user boundary; requires `RESUME_FOUNDRY_MCP_ENABLED=true` |
+| Operations | all fourteen | the nine that need no human approval and carry no packet PII |
+| `humanApprovalSecret` | header `x-resume-foundry-human-approval` only, never the body | not accepted in any form |
+| `piiApproved` | request field | not accepted |
+
+`applications.approve`, `applications.prepare`, `applications.review`, `applications.open_handoff`, and `applications.mark_submitted` are HTTP-only. They either require the human approval secret or handle raw packet PII, and a model must not be able to supply either on its own behalf.
 
 ## Agent safety rules
 
@@ -25,13 +40,13 @@ Set `RESUME_FOUNDRY_AGENT_STORE` to an absolute durable, access-controlled path 
 3. Obtain human approval before transmitting a résumé or job description to the generation endpoint.
 4. Obtain human approval before downloading, submitting, emailing, or otherwise using generated application materials.
 5. Do not claim the service stores a cloud profile. Working profile, save-point, session, and run history persistence is browser-local; lifelong career evidence is stored in an encrypted IndexedDB vault. Agent automation uses a separate explicitly configured durable store.
-6. `applications.approve` requires the separately held human approval secret. Handoff/submission marking additionally requires explicit PII approval.
-7. The server enforces `RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT`; agents cannot override it.
+6. `applications.approve` requires the separately held human approval secret, supplied as a header. Every operation that writes or returns raw packet content — `applications.prepare`, `applications.review`, `applications.open_handoff`, `applications.mark_submitted` — additionally requires explicit PII approval.
+7. The server enforces `RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT`; agents cannot override it. Quota is consumed on an application's first outward disclosure, whether that is opening a handoff or marking a submission, so it cannot be avoided by skipping the bookkeeping step.
 8. Do not expose these endpoints publicly without tenant isolation, network rate limits, and an explicit retention policy.
 
 ## Not implemented yet
 
-- OAuth-protected multi-user agent API (the local API uses a bearer secret; Google OAuth is limited to user-approved Gmail/calendar connections)
+- OAuth-protected multi-user agent API (the local HTTP API uses a bearer secret; stdio MCP has no transport authentication; Google OAuth is limited to user-approved Gmail/calendar connections)
 - MCP resources/prompts (tools are implemented)
 - A2A task endpoint and Agent Card
 - Durable asynchronous job IDs, cancellation, and webhook delivery for long-running agent work

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -2,21 +2,76 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { AGENT_OPERATIONS, executeAgentOperation } from "../lib/agent-service";
+// The explicit `.ts` extension is required: `node --experimental-strip-types`
+// performs no ESM extension resolution, so the extensionless specifier made
+// `npm run mcp` fail with ERR_MODULE_NOT_FOUND. The suite did not catch it
+// because vitest resolves bundler-style.
+import { AGENT_OPERATIONS, executeAgentOperation, type AgentOperation } from "../lib/agent-service.ts";
+
+/**
+ * Operations withheld from the stdio surface.
+ *
+ * `applications.approve` previously advertised `humanApprovalSecret` as a tool
+ * argument, which published a human-held secret into the model's own context
+ * and let the model approve on the human's behalf — the HTTP route deliberately
+ * accepts that secret only from a header for exactly this reason. The remaining
+ * operations read or write raw packet PII behind a `piiApproved` boolean that a
+ * model can simply assert about itself.
+ *
+ * Both classes stay HTTP-only, where the approval can arrive out-of-band from a
+ * human rather than from the agent making the request.
+ */
+const HTTP_ONLY_OPERATIONS: readonly AgentOperation[] = [
+  "applications.approve",
+  "applications.prepare",
+  "applications.review",
+  "applications.open_handoff",
+  "applications.mark_submitted",
+];
+
+export const MCP_OPERATIONS = AGENT_OPERATIONS.filter((operation) => !HTTP_ONLY_OPERATIONS.includes(operation));
 
 export function createResumeFoundryMcpServer() {
   const server = new McpServer({ name: "resume-foundry", version: "1.0.0" });
-  for (const operation of AGENT_OPERATIONS) {
-    server.registerTool(operation, { description: `Resume Foundry operation ${operation}. The same server-side permission policy as HTTP is enforced.`,
-      inputSchema: { input: z.record(z.string(), z.unknown()).default({}), actor: z.string().default("mcp-agent"), piiApproved: z.boolean().default(false), humanApprovalSecret: z.string().optional() } },
+  for (const operation of MCP_OPERATIONS) {
+    server.registerTool(operation, {
+      description: `Resume Foundry operation ${operation}. Runs through the same executeAgentOperation policy boundary as HTTP. Approval-gated and PII-bearing operations are not exposed over stdio.`,
+      // No `humanApprovalSecret` and no `piiApproved`: neither may originate
+      // from the model. Operations needing them are not registered here.
+      inputSchema: { input: z.record(z.string(), z.unknown()).default({}), actor: z.string().default("mcp-agent") },
+    },
     async (arguments_) => {
-      const result = await executeAgentOperation({ operation, ...arguments_ });
+      // Fields are passed explicitly rather than spread, so a future schema
+      // change cannot smuggle `operation`, `piiApproved`, or an approval
+      // secret in from tool arguments.
+      const result = await executeAgentOperation({
+        operation,
+        input: arguments_.input ?? {},
+        actor: arguments_.actor ?? "mcp-agent",
+      });
       return { content: [{ type: "text" as const, text: JSON.stringify(result) }], isError: !result.ok };
     });
   }
   return server;
 }
 
+/**
+ * A stdio server has no bearer token to check — its real trust boundary is the
+ * local user who launched the process. The previous documentation claimed
+ * bearer authentication for MCP, which was untrue. Rather than fake a check
+ * whose secret the launcher already holds, require an explicit opt-in so the
+ * surface cannot be exposed by accident, and state the boundary honestly.
+ */
+export function assertMcpEnabled(env: Record<string, string | undefined> = process.env) {
+  if (env.RESUME_FOUNDRY_MCP_ENABLED !== "true") {
+    throw new Error(
+      "Refusing to start: set RESUME_FOUNDRY_MCP_ENABLED=true to expose the stdio MCP surface. " +
+      "Anyone who can reach this process's stdio has full access to the operations it registers.",
+    );
+  }
+}
+
 if (process.argv[1]?.replaceAll("\\", "/").endsWith("scripts/mcp-server.ts")) {
+  assertMcpEnabled();
   await createResumeFoundryMcpServer().connect(new StdioServerTransport());
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
     alias: { "@": import.meta.dirname },
   },
   test: {
-    include: ["lib/**/*.test.ts"],
+    // Route, component, and script tests could not run at all under the
+    // previous lib-only pattern, so no regression test for an app/api or MCP
+    // defect was even collectable.
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts", "components/**/*.test.ts", "scripts/**/*.test.ts"],
     environment: "node",
   },
 });


### PR DESCRIPTION
Closes the P0 findings from the independent adversarial test of `6543ff0`. Every fix has a regression test that fails on the pre-fix code.

## Why this exists

The audit reproduced two things that make submission unsafe: the approval receipt **verified while the request body supplied a different board and a different résumé**, and stored packet PII **read back with no approval at all**. Both are closed here, along with the MCP entrypoint being dead, the model resolving to an invalid CLI alias, and the durable store losing writes between processes.

## Submission binding

- Routing (board/job, site/posting, Gmail message) moved into the signed preview, and the connectors lost every parameter through which unapproved content could be substituted. There is no longer a `fields`, `boardToken`, `jobId`, `site`, `postingId`, or `rawMessage` argument — routing and content are read only from the verified preview, so the original substitution is **unrepresentable** rather than merely detected.
- The provider account comes from the signed target, not `body.boardToken ?? body.site ?? "me"`, which let a caller aim an approved receipt at any other allowlisted account.
- `destination` is **derived** from the signed target. It is what the applicant reads while `target` is what the machine acts on; left independent, a preview could display a trusted employer while routing elsewhere.
- `personalDataCategories` must equal the categories actually being sent, derived from field **semantics** (not only regex matches) plus identifiers found in free text, including the Gmail message body. An unrecognised field contributes `written responses`, because employers define arbitrary field names and under-declaring a disclosure is worse than over-declaring one.
- A malformed `expiresAt` no longer means "never expires" — `NaN <= now` is `false`, so the receipt is schema-parsed before comparison. A receipt cannot grant itself a window longer than policy.
- The MAC covers canonical JSON, so verification no longer depends on JSON key order round-tripping.
- The exact frozen packet must be presented, pass `verifyApplicationPacket`, and match the approved packet, résumé, cover-letter, application id, version, employer, and role. All checks run before the nonce is consumed and before any transport.
- The Lever credential moved from the query string to a header.

## Replay and concurrency

- `lib/nonce-store.ts` claims a nonce with a single atomic `open(O_CREAT|O_EXCL)`. Proven by a test that spawns **eight real OS processes** competing for one nonce: exactly one wins.
- `lib/file-lock.ts` serialises the agent store's whole-file read-modify-write across processes. The audit proved four concurrent processes each passed a daily limit of one and three writes vanished. A test spawning real child processes now asserts exactly one success and zero lost audit entries.
- The ledger appends instead of rewriting; the audit trail is read under the same lock, because a read landing mid-rename saw `ENOENT` and came back **empty** rather than failing.

## Agent authorization

- `applications.prepare` and `applications.review` now require explicit PII approval. `review` returned the whole stored packet, so any bearer holder could read back every résumé and its identifiers.
- Daily quota is consumed on an application's **first outward disclosure**, so it can no longer be avoided by never calling `mark_submitted`.
- The approval secret is compared in constant time; a relative store path fails closed as documented; `loadStore()` moved inside the error guard because it returned the store's absolute filesystem path to callers.

## MCP

- `npm run mcp` starts again. `node --experimental-strip-types` performs no ESM extension resolution, so the extensionless import died with `ERR_MODULE_NOT_FOUND`; vitest resolved it bundler-style and never noticed.
- `humanApprovalSecret` is no longer advertised as a tool argument — that published a human-held secret into the model's own context. Approval-gated and PII-bearing operations are HTTP-only, and the stdio surface requires an explicit opt-in.
- `AGENT_ACCESS.md` no longer claims bearer authentication for MCP, which was untrue, and documents the real interface differences.

## Model

`ANTHROPIC_MODEL` leaves the fallback chain. The Claude Code CLI sets it globally, so the route resolved to the alias `opusplan` **by default** on any machine with the CLI installed — while a comment directly above asserted that could not happen.

## Breaking changes

- **Packet checksums change.** Canonicalisation moved from `localeCompare` (locale- and ICU-dependent; `"a"` sorts before `"A"` under en-US but after it by code unit) to code-unit ordering. Employer-supplied screening-answer keys reach that sort, so the same packet could hash differently on two hosts — and submission now gates on `verifyApplicationPacket`, making that a correctness risk rather than a latent one.
- Any hand-built preview with a free-form `destination` or hand-written `personalDataCategories` is now rejected.

## Testing

`vitest` collected only `lib/**`, so **no route, component, or script test could run at all**. Widened. The MCP parity test is now behavioural instead of grepping source text, and the OpenAPI contract test asserts both directions so an advertised-but-nonexistent operation is caught.

170 tests pass; lint, typecheck, build, and audit are clean and contract generation produces no diff.

## Known limits, not claimed as fixed

- **Exactly-once submission is not achievable** with these providers. At-most-once per receipt is enforced, but an uncertain failure after the provider accepted still permits a duplicate on re-approval, and neither Greenhouse nor Lever documents an idempotency key.
- `mode: 0o600` is not enforced on Windows, so the store holding packet PII is readable by other local users on a Windows host.
- `applications.ts transitionApplication` assigns a **new packet id** on submission and leaves résumé/cover-letter checksums stale, which breaks this binding if the UI transitions before calling execute. Needs an owner.
- `lib/pii.ts` still misses undashed and non-US phone numbers and has no personal-name pattern.
- `/api/submissions/execute` still reads its body unbounded; the shared bounded-body helper lands in the network branch.
