### PR TITLE
Harden Windows sensitive-store ACL enforcement

### DIFF
--- a/docs/WINDOWS_STORAGE_ACL.md
+++ b/docs/WINDOWS_STORAGE_ACL.md
@@ -8,7 +8,7 @@ On Windows, `npm start` checks every configured sensitive path in its `prestart`
 RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply
 ```
 
-for a service account that is allowed to create and secure its dedicated directories, or use `verify` when directories are provisioned separately. If a sensitive store is configured in Windows production and the mode is missing, `off`, invalid, or verification fails, `npm start` exits before launching Next.js. The instrumentation backstop rejects runtime initialization. Development skips the check unless a mode is explicitly selected.
+for a service account that is allowed to create and secure its dedicated directories, or use `verify` when directories are provisioned separately. When any sensitive path is configured, the mode is mandatory unless `NODE_ENV` is explicitly `development` or `test`; an unset or misspelled environment is treated as production-sensitive and fails closed. If the mode is missing, `off`, invalid, or verification fails, `npm start` exits before launching Next.js. The instrumentation backstop rejects runtime initialization.
 
 The boundary recognizes these paths:
 
@@ -29,6 +29,8 @@ The PowerShell helper uses .NET's supported `System.Security.AccessControl` APIs
 3. replaces access rules with full control for the service identity, Local System, and the local Administrators group;
 4. reads the resulting ACL back; and
 5. fails unless inheritance is disabled, the service identity owns the directory and has full control, and no other principal has an allow rule.
+
+Before `apply` creates a missing directory, a separate component-by-component preflight rejects reparse points in every existing ancestor, so creation cannot be redirected through a junction. Existing directory trees are then walked without following reparse points. Every existing child is verified and `apply` replaces its ACL; a junction, symbolic link, mount point, or other reparse point in the configured path or tree fails the check. Deny rules fail verification, inherit-only rules are not counted as effective access, and the service identity, Local System, and Administrators must each retain effective full control.
 
 `verify` performs only steps 4 and 5.
 

--- a/docs/WINDOWS_STORAGE_ACL.md
+++ b/docs/WINDOWS_STORAGE_ACL.md
@@ -1,0 +1,43 @@
+# Windows server-side storage ACL boundary
+
+Resume Foundry stores résumé packets, submission receipts, nonce markers, rate-limit slots, and audit records on the server when those capabilities are enabled. `mode: 0o600` is a POSIX creation hint; Node does not turn it into an owner-only NTFS ACL on Windows.
+
+On Windows, `npm start` checks every configured sensitive path in its `prestart` gate. `instrumentation.ts` repeats the boundary during Next.js runtime initialization so an alternate launcher cannot serve a protected route without passing it. Set:
+
+```text
+RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply
+```
+
+for a service account that is allowed to create and secure its dedicated directories, or use `verify` when directories are provisioned separately. If a sensitive store is configured in Windows production and the mode is missing, `off`, invalid, or verification fails, `npm start` exits before launching Next.js. The instrumentation backstop rejects runtime initialization. Development skips the check unless a mode is explicitly selected.
+
+The boundary recognizes these paths:
+
+- `RESUME_FOUNDRY_AGENT_STORE` (file; its containing directory is secured)
+- `RESUME_FOUNDRY_SUBMISSION_LEDGER` (file; its containing directory is secured)
+- `RESUME_FOUNDRY_NONCE_STORE` (directory)
+- `RESUME_FOUNDRY_RATE_LIMIT_DIR` (directory)
+- `RESUME_FOUNDRY_AUDIT_STORE` (file; its containing directory is secured)
+
+The file stores use atomic replacement, so securing the containing directory is essential: replacement files inherit that directory's ACL. An already-existing configured file is checked and, in `apply` mode, secured separately so an old protected or explicit ACL cannot survive merely because its parent changed. Filesystem-root directories are refused. Put each deployment's sensitive files below a dedicated directory.
+
+## What `apply` does
+
+The PowerShell helper uses .NET's supported `System.Security.AccessControl` APIs with literal paths. Node launches the checked-in script with `execFile` and an argument array; configured paths are never concatenated into a shell command. The helper:
+
+1. disables inherited access rules;
+2. sets the service identity as owner;
+3. replaces access rules with full control for the service identity, Local System, and the local Administrators group;
+4. reads the resulting ACL back; and
+5. fails unless inheritance is disabled, the service identity owns the directory and has full control, and no other principal has an allow rule.
+
+`verify` performs only steps 4 and 5.
+
+## Security boundary and limits
+
+- This blocks access by other ordinary local users. It cannot stop Local System or an administrator, who are deliberately retained and can take ownership on Windows regardless.
+- It does not encrypt data at rest, protect a compromised service identity, secure backups, or replace disk encryption.
+- ACL safety depends on a trusted local filesystem. Container bind mounts, SMB shares, non-NTFS filesystems, orchestrator-mounted secrets, and volume drivers may have different permission semantics and must be validated by that deployment.
+- A parent administrator can change ACLs after startup. Production monitoring should periodically run verification and alert on drift.
+- On Linux/macOS this Windows check reports `not-applicable`; deployment-specific POSIX ownership/mode checks remain required. No cross-platform owner-only claim is made.
+- Paths and the checked-in PowerShell helper must ship together. Missing helper files fail the prestart/runtime check when checking is required.
+- Launchers that bypass `npm start` should run `node --experimental-strip-types scripts/check-windows-sensitive-paths.mjs` before starting the process. The instrumentation hook is defense in depth, not a substitute for an orchestrator that treats a failed preflight as a failed deployment.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,7 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  const { enforceConfiguredWindowsSensitivePathAcls } = await import(
+    "./lib/windows-sensitive-path-acl"
+  );
+  await enforceConfiguredWindowsSensitivePathAcls();
+}

--- a/lib/windows-sensitive-path-acl.test.ts
+++ b/lib/windows-sensitive-path-acl.test.ts
@@ -1,0 +1,189 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  enforceConfiguredWindowsSensitivePathAcls,
+  runWindowsAclScript,
+  type WindowsAclRunner,
+} from "./windows-sensitive-path-acl";
+
+const secureResult = {
+  secure: true,
+  ownerSid: "S-1-5-21-test",
+  inheritanceProtected: true,
+  unexpectedAllowSids: [],
+  currentUserHasFullControl: true,
+};
+
+const roots: string[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempRoot() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "rf-acl-test-"));
+  roots.push(root);
+  return root;
+}
+
+describe("Windows sensitive-path ACL startup boundary", () => {
+  it("does nothing when no sensitive server-side store is configured", async () => {
+    const runner = vi.fn<WindowsAclRunner>();
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({ env: {}, platform: "win32", production: true, runner }),
+    ).resolves.toEqual({ status: "not-configured", checked: [] });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("does not claim that NTFS ACLs protect non-Windows deployments", async () => {
+    const runner = vi.fn<WindowsAclRunner>();
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: { RESUME_FOUNDRY_AGENT_STORE: "/private/store.json" },
+        platform: "linux",
+        production: true,
+        runner,
+      }),
+    ).resolves.toEqual({ status: "not-applicable", checked: [] });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("fails closed in Windows production until apply or verify is explicitly selected", async () => {
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: { NODE_ENV: "production", RESUME_FOUNDRY_AGENT_STORE: "C:\\private\\agent.json" },
+        platform: "win32",
+      }),
+    ).rejects.toThrow(/RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply or verify is required/);
+  });
+
+  it("allows development to opt out without making a security claim", async () => {
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: { RESUME_FOUNDRY_AGENT_STORE: "C:\\private\\agent.json" },
+        platform: "win32",
+        production: false,
+      }),
+    ).resolves.toEqual({ status: "skipped", checked: [] });
+  });
+
+  it("rejects relative paths and filesystem-root parent directories", async () => {
+    const runner = vi.fn<WindowsAclRunner>();
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: {
+          RESUME_FOUNDRY_WINDOWS_ACL_MODE: "verify",
+          RESUME_FOUNDRY_AGENT_STORE: "relative\\agent.json",
+        },
+        platform: "win32",
+        runner,
+      }),
+    ).rejects.toThrow(/absolute Windows path/);
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: {
+          RESUME_FOUNDRY_WINDOWS_ACL_MODE: "verify",
+          RESUME_FOUNDRY_AGENT_STORE: "C:\\agent.json",
+        },
+        platform: "win32",
+        runner,
+      }),
+    ).rejects.toThrow(/filesystem-root parent/);
+  });
+
+  it("deduplicates shared directories and applies before verifying the result", async () => {
+    const root = await tempRoot();
+    const runner = vi.fn<WindowsAclRunner>().mockResolvedValue(secureResult);
+    const env = {
+      RESUME_FOUNDRY_WINDOWS_ACL_MODE: "apply",
+      RESUME_FOUNDRY_AGENT_STORE: path.join(root, "private", "agent.json"),
+      RESUME_FOUNDRY_SUBMISSION_LEDGER: path.join(root, "private", "submissions.jsonl"),
+      RESUME_FOUNDRY_NONCE_STORE: path.join(root, "nonces"),
+    };
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({ env, platform: "win32", production: true, runner }),
+    ).resolves.toEqual({
+      status: "secured",
+      checked: [
+        "RESUME_FOUNDRY_AGENT_STORE",
+        "RESUME_FOUNDRY_NONCE_STORE",
+        "RESUME_FOUNDRY_SUBMISSION_LEDGER",
+      ],
+    });
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(runner).toHaveBeenCalledWith({
+      targetPath: path.join(root, "private"),
+      mode: "apply",
+      kind: "directory",
+    });
+    expect(runner).toHaveBeenCalledWith({
+      targetPath: path.join(root, "nonces"),
+      mode: "apply",
+      kind: "directory",
+    });
+  });
+
+  it("checks an existing sensitive file as well as its containing directory", async () => {
+    const root = await tempRoot();
+    const store = path.join(root, "agent.json");
+    await writeFile(store, "{}");
+    const runner = vi.fn<WindowsAclRunner>().mockResolvedValue(secureResult);
+    await enforceConfiguredWindowsSensitivePathAcls({
+      env: {
+        RESUME_FOUNDRY_WINDOWS_ACL_MODE: "verify",
+        RESUME_FOUNDRY_AGENT_STORE: store,
+      },
+      platform: "win32",
+      production: true,
+      runner,
+    });
+    expect(runner).toHaveBeenNthCalledWith(1, { targetPath: root, mode: "verify", kind: "directory" });
+    expect(runner).toHaveBeenNthCalledWith(2, { targetPath: store, mode: "verify", kind: "file" });
+  });
+
+  it("fails closed when verification reports an unexpected principal", async () => {
+    const root = await tempRoot();
+    const runner = vi.fn<WindowsAclRunner>().mockResolvedValue({
+      ...secureResult,
+      secure: false,
+      unexpectedAllowSids: ["S-1-5-32-545"],
+    });
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: {
+          RESUME_FOUNDRY_WINDOWS_ACL_MODE: "verify",
+          RESUME_FOUNDRY_RATE_LIMIT_DIR: root,
+        },
+        platform: "win32",
+        production: true,
+        runner,
+      }),
+    ).rejects.toThrow(/unexpectedAllowCount=1/);
+  });
+
+  it.runIf(process.platform === "win32")(
+    "applies and independently verifies an ACL only inside a disposable temporary directory",
+    async () => {
+      const root = await tempRoot();
+      const applied = await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      expect(applied).toMatchObject({
+        secure: true,
+        inheritanceProtected: true,
+        unexpectedAllowSids: [],
+        currentUserHasFullControl: true,
+      });
+      const file = path.join(root, "existing.json");
+      await writeFile(file, "{}");
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).resolves.toMatchObject({
+        secure: true,
+      });
+      await expect(
+        runWindowsAclScript({ targetPath: file, mode: "apply", kind: "file" }),
+      ).resolves.toMatchObject({ secure: true });
+    },
+  );
+});

--- a/lib/windows-sensitive-path-acl.test.ts
+++ b/lib/windows-sensitive-path-acl.test.ts
@@ -1,6 +1,8 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   enforceConfiguredWindowsSensitivePathAcls,
@@ -15,6 +17,7 @@ const secureResult = {
   unexpectedAllowSids: [],
   currentUserHasFullControl: true,
 };
+const execFileAsync = promisify(execFile);
 
 const roots: string[] = [];
 afterEach(async () => {
@@ -32,7 +35,7 @@ describe("Windows sensitive-path ACL startup boundary", () => {
   it("does nothing when no sensitive server-side store is configured", async () => {
     const runner = vi.fn<WindowsAclRunner>();
     await expect(
-      enforceConfiguredWindowsSensitivePathAcls({ env: {}, platform: "win32", production: true, runner }),
+      enforceConfiguredWindowsSensitivePathAcls({ env: {}, platform: "win32", runner }),
     ).resolves.toEqual({ status: "not-configured", checked: [] });
     expect(runner).not.toHaveBeenCalled();
   });
@@ -43,7 +46,6 @@ describe("Windows sensitive-path ACL startup boundary", () => {
       enforceConfiguredWindowsSensitivePathAcls({
         env: { RESUME_FOUNDRY_AGENT_STORE: "/private/store.json" },
         platform: "linux",
-        production: true,
         runner,
       }),
     ).resolves.toEqual({ status: "not-applicable", checked: [] });
@@ -62,11 +64,22 @@ describe("Windows sensitive-path ACL startup boundary", () => {
   it("allows development to opt out without making a security claim", async () => {
     await expect(
       enforceConfiguredWindowsSensitivePathAcls({
-        env: { RESUME_FOUNDRY_AGENT_STORE: "C:\\private\\agent.json" },
+        env: { NODE_ENV: "development", RESUME_FOUNDRY_AGENT_STORE: "C:\\private\\agent.json" },
         platform: "win32",
-        production: false,
       }),
     ).resolves.toEqual({ status: "skipped", checked: [] });
+  });
+
+  it("fails closed when NODE_ENV is unset and ACL enforcement is off", async () => {
+    await expect(
+      enforceConfiguredWindowsSensitivePathAcls({
+        env: {
+          RESUME_FOUNDRY_WINDOWS_ACL_MODE: "off",
+          RESUME_FOUNDRY_AGENT_STORE: "C:\\private\\agent.json",
+        },
+        platform: "win32",
+      }),
+    ).rejects.toThrow(/apply or verify is required/);
   });
 
   it("rejects relative paths and filesystem-root parent directories", async () => {
@@ -103,7 +116,7 @@ describe("Windows sensitive-path ACL startup boundary", () => {
       RESUME_FOUNDRY_NONCE_STORE: path.join(root, "nonces"),
     };
     await expect(
-      enforceConfiguredWindowsSensitivePathAcls({ env, platform: "win32", production: true, runner }),
+      enforceConfiguredWindowsSensitivePathAcls({ env, platform: "win32", runner }),
     ).resolves.toEqual({
       status: "secured",
       checked: [
@@ -112,7 +125,12 @@ describe("Windows sensitive-path ACL startup boundary", () => {
         "RESUME_FOUNDRY_SUBMISSION_LEDGER",
       ],
     });
-    expect(runner).toHaveBeenCalledTimes(2);
+    expect(runner).toHaveBeenCalledTimes(4);
+    expect(runner).toHaveBeenCalledWith({
+      targetPath: path.join(root, "private"),
+      mode: "preflight",
+      kind: "directory",
+    });
     expect(runner).toHaveBeenCalledWith({
       targetPath: path.join(root, "private"),
       mode: "apply",
@@ -136,20 +154,27 @@ describe("Windows sensitive-path ACL startup boundary", () => {
         RESUME_FOUNDRY_AGENT_STORE: store,
       },
       platform: "win32",
-      production: true,
       runner,
     });
-    expect(runner).toHaveBeenNthCalledWith(1, { targetPath: root, mode: "verify", kind: "directory" });
-    expect(runner).toHaveBeenNthCalledWith(2, { targetPath: store, mode: "verify", kind: "file" });
+    expect(runner).toHaveBeenNthCalledWith(1, {
+      targetPath: root,
+      mode: "preflight",
+      kind: "directory",
+    });
+    expect(runner).toHaveBeenNthCalledWith(2, { targetPath: root, mode: "verify", kind: "directory" });
+    expect(runner).toHaveBeenNthCalledWith(3, { targetPath: store, mode: "verify", kind: "file" });
   });
 
   it("fails closed when verification reports an unexpected principal", async () => {
     const root = await tempRoot();
-    const runner = vi.fn<WindowsAclRunner>().mockResolvedValue({
-      ...secureResult,
-      secure: false,
-      unexpectedAllowSids: ["S-1-5-32-545"],
-    });
+    const runner = vi
+      .fn<WindowsAclRunner>()
+      .mockResolvedValueOnce(secureResult)
+      .mockResolvedValueOnce({
+        ...secureResult,
+        secure: false,
+        unexpectedAllowSids: ["S-1-5-32-545"],
+      });
     await expect(
       enforceConfiguredWindowsSensitivePathAcls({
         env: {
@@ -157,7 +182,6 @@ describe("Windows sensitive-path ACL startup boundary", () => {
           RESUME_FOUNDRY_RATE_LIMIT_DIR: root,
         },
         platform: "win32",
-        production: true,
         runner,
       }),
     ).rejects.toThrow(/unexpectedAllowCount=1/);
@@ -184,6 +208,139 @@ describe("Windows sensitive-path ACL startup boundary", () => {
       await expect(
         runWindowsAclScript({ targetPath: file, mode: "apply", kind: "file" }),
       ).resolves.toMatchObject({ secure: true });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects a configured directory reached through a junction",
+    async () => {
+      const root = await tempRoot();
+      const target = path.join(root, "actual");
+      const junction = path.join(root, "junction");
+      await mkdir(target);
+      await symlink(target, junction, "junction");
+      await expect(
+        enforceConfiguredWindowsSensitivePathAcls({
+          env: {
+            NODE_ENV: "production",
+            RESUME_FOUNDRY_WINDOWS_ACL_MODE: "verify",
+            RESUME_FOUNDRY_NONCE_STORE: junction,
+          },
+          platform: "win32",
+        }),
+      ).rejects.toThrow(/reparse/i);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects a junction in an ancestor and a reparse point inside a configured tree",
+    async () => {
+      const root = await tempRoot();
+      const target = path.join(root, "actual");
+      const nested = path.join(target, "nested");
+      const junction = path.join(root, "junction");
+      await mkdir(nested, { recursive: true });
+      await symlink(target, junction, "junction");
+      await expect(
+        runWindowsAclScript({
+          targetPath: path.join(junction, "nested"),
+          mode: "verify",
+          kind: "directory",
+        }),
+      ).rejects.toThrow(/reparse/i);
+
+      const cleanTree = path.join(root, "clean-tree");
+      const outside = path.join(root, "outside");
+      await mkdir(cleanTree);
+      await mkdir(outside);
+      await symlink(outside, path.join(cleanTree, "child-link"), "junction");
+      await expect(
+        runWindowsAclScript({ targetPath: cleanTree, mode: "apply", kind: "directory" }),
+      ).rejects.toThrow(/reparse/i);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects a missing directory below a junction before creating anything through it",
+    async () => {
+      const root = await tempRoot();
+      const target = path.join(root, "actual");
+      const junction = path.join(root, "junction");
+      const createdThroughJunction = path.join(target, "must-not-exist");
+      await mkdir(target);
+      await symlink(target, junction, "junction");
+      await expect(
+        enforceConfiguredWindowsSensitivePathAcls({
+          env: {
+            RESUME_FOUNDRY_WINDOWS_ACL_MODE: "apply",
+            RESUME_FOUNDRY_NONCE_STORE: path.join(junction, "must-not-exist"),
+          },
+          platform: "win32",
+        }),
+      ).rejects.toThrow(/reparse/i);
+      await expect(stat(createdThroughJunction)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "detects and repairs a permissive ACL on an existing child",
+    async () => {
+      const root = await tempRoot();
+      const child = path.join(root, "marker.used");
+      await writeFile(child, "used");
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      await execFileAsync("icacls.exe", [child, "/grant", "*S-1-5-32-545:F"]);
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).rejects.toThrow();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).resolves.toMatchObject({ secure: true });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "does not report secure when the owner has an explicit deny rule",
+    async () => {
+      const root = await tempRoot();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      const child = path.join(root, "denied.json");
+      await writeFile(child, "{}");
+      const identity = `${process.env.USERDOMAIN}\\${process.env.USERNAME}`;
+      await execFileAsync("icacls.exe", [child, "/deny", `${identity}:(W)`]);
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).rejects.toThrow();
+      await execFileAsync("icacls.exe", [child, "/remove:d", identity]);
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "does not count an inherit-only administrator ACE as effective full control",
+    async () => {
+      const root = await tempRoot();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      await execFileAsync("icacls.exe", [root, "/remove:g", "*S-1-5-32-544"]);
+      await execFileAsync("icacls.exe", [root, "/grant", "*S-1-5-32-544:(OI)(CI)(IO)F"]);
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).rejects.toThrow();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "requires Local System as well as owner and Administrators to have full control",
+    async () => {
+      const root = await tempRoot();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
+      await execFileAsync("icacls.exe", [root, "/remove:g", "*S-1-5-18"]);
+      await expect(
+        runWindowsAclScript({ targetPath: root, mode: "verify", kind: "directory" }),
+      ).rejects.toThrow();
+      await runWindowsAclScript({ targetPath: root, mode: "apply", kind: "directory" });
     },
   );
 });

--- a/lib/windows-sensitive-path-acl.test.ts
+++ b/lib/windows-sensitive-path-acl.test.ts
@@ -116,7 +116,7 @@ describe("Windows sensitive-path ACL startup boundary", () => {
       RESUME_FOUNDRY_NONCE_STORE: path.join(root, "nonces"),
     };
     await expect(
-      enforceConfiguredWindowsSensitivePathAcls({ env, platform: "win32", runner }),
+      enforceConfiguredWindowsSensitivePathAcls({ env, platform: "win32", runner, pathApi: path }),
     ).resolves.toEqual({
       status: "secured",
       checked: [
@@ -155,6 +155,7 @@ describe("Windows sensitive-path ACL startup boundary", () => {
       },
       platform: "win32",
       runner,
+      pathApi: path,
     });
     expect(runner).toHaveBeenNthCalledWith(1, {
       targetPath: root,
@@ -183,6 +184,7 @@ describe("Windows sensitive-path ACL startup boundary", () => {
         },
         platform: "win32",
         runner,
+        pathApi: path,
       }),
     ).rejects.toThrow(/unexpectedAllowCount=1/);
   });

--- a/lib/windows-sensitive-path-acl.ts
+++ b/lib/windows-sensitive-path-acl.ts
@@ -56,23 +56,23 @@ function parseMode(value: string | undefined): WindowsAclMode | undefined {
   throw new Error(`${WINDOWS_ACL_MODE_ENV} must be apply, verify, or off.`);
 }
 
-function assertSafeAbsolutePath(configured: string, envName: string) {
-  if (!path.win32.isAbsolute(configured)) {
+function assertSafeAbsolutePath(configured: string, envName: string, pathApi: typeof path.win32) {
+  if (!pathApi.isAbsolute(configured)) {
     throw new Error(`${envName} must be an absolute Windows path before its ACL can be checked.`);
   }
-  const resolved = path.win32.resolve(configured);
-  if (resolved === path.win32.parse(resolved).root) {
+  const resolved = pathApi.resolve(configured);
+  if (resolved === pathApi.parse(resolved).root) {
     throw new Error(`${envName} must not target a filesystem root.`);
   }
   return resolved;
 }
 
-function uniqueDirectories(env: AclEnvironment) {
+function uniqueDirectories(env: AclEnvironment, pathApi: typeof path.win32) {
   const byCanonicalPath = new Map<string, { path: string; envNames: string[] }>();
   for (const target of configuredTargets(env)) {
-    const resolved = assertSafeAbsolutePath(target.configured, target.env);
-    const directory = target.kind === "file" ? path.win32.dirname(resolved) : resolved;
-    if (directory === path.win32.parse(directory).root) {
+    const resolved = assertSafeAbsolutePath(target.configured, target.env, pathApi);
+    const directory = target.kind === "file" ? pathApi.dirname(resolved) : resolved;
+    if (directory === pathApi.parse(directory).root) {
       throw new Error(`${target.env} has a filesystem-root parent; use a dedicated private directory.`);
     }
     const key = directory.toLowerCase();
@@ -120,6 +120,7 @@ export async function enforceConfiguredWindowsSensitivePathAcls(options: {
   env?: AclEnvironment;
   platform?: NodeJS.Platform;
   runner?: WindowsAclRunner;
+  pathApi?: typeof path.win32;
 } = {}): Promise<SensitivePathAclResult> {
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
@@ -141,8 +142,9 @@ export async function enforceConfiguredWindowsSensitivePathAcls(options: {
   }
 
   const runner = options.runner ?? runWindowsAclScript;
+  const pathApi = options.pathApi ?? path.win32;
   const checked: string[] = [];
-  for (const directory of uniqueDirectories(env)) {
+  for (const directory of uniqueDirectories(env, pathApi)) {
     const preflight = await runner({ targetPath: directory.path, mode: "preflight", kind: "directory" });
     if (!preflight.secure) {
       throw new Error(`${directory.envNames.join("/")} failed the Windows reparse-point preflight.`);
@@ -163,7 +165,7 @@ export async function enforceConfiguredWindowsSensitivePathAcls(options: {
     checked.push(...directory.envNames);
   }
   for (const target of targets.filter((entry) => entry.kind === "file")) {
-    const resolved = assertSafeAbsolutePath(target.configured, target.env);
+    const resolved = assertSafeAbsolutePath(target.configured, target.env, pathApi);
     const info = await stat(resolved).catch(() => undefined);
     if (!info) continue;
     if (!info.isFile()) throw new Error(`${target.env} must identify a regular file.`);

--- a/lib/windows-sensitive-path-acl.ts
+++ b/lib/windows-sensitive-path-acl.ts
@@ -1,0 +1,169 @@
+import { access, mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const WINDOWS_ACL_MODE_ENV = "RESUME_FOUNDRY_WINDOWS_ACL_MODE";
+
+const SENSITIVE_PATHS = [
+  { env: "RESUME_FOUNDRY_AGENT_STORE", kind: "file" },
+  { env: "RESUME_FOUNDRY_SUBMISSION_LEDGER", kind: "file" },
+  { env: "RESUME_FOUNDRY_NONCE_STORE", kind: "directory" },
+  { env: "RESUME_FOUNDRY_RATE_LIMIT_DIR", kind: "directory" },
+  { env: "RESUME_FOUNDRY_AUDIT_STORE", kind: "file" },
+] as const;
+
+export type WindowsAclMode = "apply" | "verify";
+export type AclEnvironment = Record<string, string | undefined>;
+
+export interface WindowsAclRunnerResult {
+  secure: boolean;
+  ownerSid: string;
+  inheritanceProtected: boolean;
+  unexpectedAllowSids: string[];
+  currentUserHasFullControl: boolean;
+}
+
+export type WindowsAclRunner = (input: {
+  targetPath: string;
+  mode: WindowsAclMode;
+  kind: "directory" | "file";
+}) => Promise<WindowsAclRunnerResult>;
+
+export interface SensitivePathAclResult {
+  status: "not-applicable" | "not-configured" | "skipped" | "secured";
+  checked: string[];
+}
+
+function configuredTargets(env: AclEnvironment) {
+  return SENSITIVE_PATHS.flatMap((entry) => {
+    const configured = env[entry.env]?.trim();
+    return configured ? [{ ...entry, configured }] : [];
+  });
+}
+
+function parseMode(value: string | undefined): WindowsAclMode | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized || normalized === "off") return undefined;
+  if (normalized === "apply" || normalized === "verify") return normalized;
+  throw new Error(`${WINDOWS_ACL_MODE_ENV} must be apply, verify, or off.`);
+}
+
+function assertSafeAbsolutePath(configured: string, envName: string) {
+  if (!path.win32.isAbsolute(configured)) {
+    throw new Error(`${envName} must be an absolute Windows path before its ACL can be checked.`);
+  }
+  const resolved = path.win32.resolve(configured);
+  if (resolved === path.win32.parse(resolved).root) {
+    throw new Error(`${envName} must not target a filesystem root.`);
+  }
+  return resolved;
+}
+
+function uniqueDirectories(env: AclEnvironment) {
+  const byCanonicalPath = new Map<string, { path: string; envNames: string[] }>();
+  for (const target of configuredTargets(env)) {
+    const resolved = assertSafeAbsolutePath(target.configured, target.env);
+    const directory = target.kind === "file" ? path.win32.dirname(resolved) : resolved;
+    if (directory === path.win32.parse(directory).root) {
+      throw new Error(`${target.env} has a filesystem-root parent; use a dedicated private directory.`);
+    }
+    const key = directory.toLowerCase();
+    const previous = byCanonicalPath.get(key);
+    if (previous) previous.envNames.push(target.env);
+    else byCanonicalPath.set(key, { path: directory, envNames: [target.env] });
+  }
+  return [...byCanonicalPath.values()];
+}
+
+export async function runWindowsAclScript(input: {
+  targetPath: string;
+  mode: WindowsAclMode;
+  kind: "directory" | "file";
+}): Promise<WindowsAclRunnerResult> {
+  const script = path.join(process.cwd(), "scripts", "windows-sensitive-path-acl.ps1");
+  await access(script);
+  const { stdout } = await execFileAsync(
+    "powershell.exe",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      script,
+      "-Mode",
+      input.mode,
+      "-TargetPath",
+      input.targetPath,
+      "-Kind",
+      input.kind,
+    ],
+    { windowsHide: true, timeout: 30_000, maxBuffer: 64 * 1024 },
+  );
+  const parsed = JSON.parse(stdout.trim()) as WindowsAclRunnerResult;
+  if (typeof parsed.secure !== "boolean" || !Array.isArray(parsed.unexpectedAllowSids)) {
+    throw new Error("Windows ACL helper returned an invalid result.");
+  }
+  return parsed;
+}
+
+export async function enforceConfiguredWindowsSensitivePathAcls(options: {
+  env?: AclEnvironment;
+  platform?: NodeJS.Platform;
+  production?: boolean;
+  runner?: WindowsAclRunner;
+} = {}): Promise<SensitivePathAclResult> {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const production = options.production ?? env.NODE_ENV === "production";
+  const targets = configuredTargets(env);
+
+  if (targets.length === 0) return { status: "not-configured", checked: [] };
+  if (platform !== "win32") return { status: "not-applicable", checked: [] };
+
+  const mode = parseMode(env[WINDOWS_ACL_MODE_ENV]);
+  if (!mode) {
+    if (production) {
+      throw new Error(
+        `${WINDOWS_ACL_MODE_ENV}=apply or verify is required in production when sensitive Windows paths are configured.`,
+      );
+    }
+    return { status: "skipped", checked: [] };
+  }
+
+  const runner = options.runner ?? runWindowsAclScript;
+  const checked: string[] = [];
+  for (const directory of uniqueDirectories(env)) {
+    if (mode === "apply") await mkdir(directory.path, { recursive: true });
+    else {
+      const info = await stat(directory.path).catch(() => undefined);
+      if (!info?.isDirectory()) {
+        throw new Error(`${directory.envNames.join("/")} private directory does not exist.`);
+      }
+    }
+    const result = await runner({ targetPath: directory.path, mode, kind: "directory" });
+    if (!result.secure) {
+      throw new Error(
+        `${directory.envNames.join("/")} failed the Windows ACL boundary: inheritanceProtected=${result.inheritanceProtected}, currentUserFullControl=${result.currentUserHasFullControl}, unexpectedAllowCount=${result.unexpectedAllowSids.length}.`,
+      );
+    }
+    checked.push(...directory.envNames);
+  }
+  for (const target of targets.filter((entry) => entry.kind === "file")) {
+    const resolved = assertSafeAbsolutePath(target.configured, target.env);
+    const info = await stat(resolved).catch(() => undefined);
+    if (!info) continue;
+    if (!info.isFile()) throw new Error(`${target.env} must identify a regular file.`);
+    const result = await runner({ targetPath: resolved, mode, kind: "file" });
+    if (!result.secure) {
+      throw new Error(
+        `${target.env} file failed the Windows ACL boundary: inheritanceProtected=${result.inheritanceProtected}, currentUserFullControl=${result.currentUserHasFullControl}, unexpectedAllowCount=${result.unexpectedAllowSids.length}.`,
+      );
+    }
+  }
+  return { status: "secured", checked: checked.sort() };
+}

--- a/lib/windows-sensitive-path-acl.ts
+++ b/lib/windows-sensitive-path-acl.ts
@@ -16,6 +16,7 @@ const SENSITIVE_PATHS = [
 ] as const;
 
 export type WindowsAclMode = "apply" | "verify";
+export type WindowsAclOperation = WindowsAclMode | "preflight";
 export type AclEnvironment = Record<string, string | undefined>;
 
 export interface WindowsAclRunnerResult {
@@ -24,11 +25,15 @@ export interface WindowsAclRunnerResult {
   inheritanceProtected: boolean;
   unexpectedAllowSids: string[];
   currentUserHasFullControl: boolean;
+  missingFullControlSids?: string[];
+  denyRuleCount?: number;
+  inheritedRuleCount?: number;
+  checkedItemCount?: number;
 }
 
 export type WindowsAclRunner = (input: {
   targetPath: string;
-  mode: WindowsAclMode;
+  mode: WindowsAclOperation;
   kind: "directory" | "file";
 }) => Promise<WindowsAclRunnerResult>;
 
@@ -80,7 +85,7 @@ function uniqueDirectories(env: AclEnvironment) {
 
 export async function runWindowsAclScript(input: {
   targetPath: string;
-  mode: WindowsAclMode;
+  mode: WindowsAclOperation;
   kind: "directory" | "file";
 }): Promise<WindowsAclRunnerResult> {
   const script = path.join(process.cwd(), "scripts", "windows-sensitive-path-acl.ps1");
@@ -114,12 +119,12 @@ export async function runWindowsAclScript(input: {
 export async function enforceConfiguredWindowsSensitivePathAcls(options: {
   env?: AclEnvironment;
   platform?: NodeJS.Platform;
-  production?: boolean;
   runner?: WindowsAclRunner;
 } = {}): Promise<SensitivePathAclResult> {
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
-  const production = options.production ?? env.NODE_ENV === "production";
+  const environment = env.NODE_ENV?.trim().toLowerCase();
+  const explicitlyNonProduction = environment === "development" || environment === "test";
   const targets = configuredTargets(env);
 
   if (targets.length === 0) return { status: "not-configured", checked: [] };
@@ -127,7 +132,7 @@ export async function enforceConfiguredWindowsSensitivePathAcls(options: {
 
   const mode = parseMode(env[WINDOWS_ACL_MODE_ENV]);
   if (!mode) {
-    if (production) {
+    if (!explicitlyNonProduction) {
       throw new Error(
         `${WINDOWS_ACL_MODE_ENV}=apply or verify is required in production when sensitive Windows paths are configured.`,
       );
@@ -138,6 +143,10 @@ export async function enforceConfiguredWindowsSensitivePathAcls(options: {
   const runner = options.runner ?? runWindowsAclScript;
   const checked: string[] = [];
   for (const directory of uniqueDirectories(env)) {
+    const preflight = await runner({ targetPath: directory.path, mode: "preflight", kind: "directory" });
+    if (!preflight.secure) {
+      throw new Error(`${directory.envNames.join("/")} failed the Windows reparse-point preflight.`);
+    }
     if (mode === "apply") await mkdir(directory.path, { recursive: true });
     else {
       const info = await stat(directory.path).catch(() => undefined);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "prestart": "node --experimental-strip-types scripts/check-windows-sensitive-paths.mjs",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-windows-sensitive-paths.mjs
+++ b/scripts/check-windows-sensitive-paths.mjs
@@ -1,0 +1,6 @@
+import { enforceConfiguredWindowsSensitivePathAcls } from "../lib/windows-sensitive-path-acl.ts";
+
+const result = await enforceConfiguredWindowsSensitivePathAcls();
+if (result.status === "secured") {
+  process.stdout.write(`Windows sensitive-storage ACL check passed (${result.checked.length} paths).\n`);
+}

--- a/scripts/windows-sensitive-path-acl.ps1
+++ b/scripts/windows-sensitive-path-acl.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory = $true)]
-  [ValidateSet("apply", "verify")]
+  [ValidateSet("apply", "verify", "preflight")]
   [string]$Mode,
 
   [Parameter(Mandatory = $true)]
@@ -12,103 +12,204 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$reparsePoint = [System.IO.FileAttributes]::ReparsePoint
+$directoryAttribute = [System.IO.FileAttributes]::Directory
 
-function Get-SecurityResult([string]$LiteralPath, [string]$ItemKind) {
+function Assert-NoReparseComponents([string]$LiteralPath) {
+  $fullPath = [System.IO.Path]::GetFullPath($LiteralPath)
+  $root = [System.IO.Path]::GetPathRoot($fullPath)
+  $current = $root
+  $relative = $fullPath.Substring($root.Length)
+  foreach ($segment in $relative.Split(
+    [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar),
+    [System.StringSplitOptions]::RemoveEmptyEntries
+  )) {
+    $current = [System.IO.Path]::Combine($current, $segment)
+    if (-not ([System.IO.Directory]::Exists($current) -or [System.IO.File]::Exists($current))) {
+      break
+    }
+    $attributes = [System.IO.File]::GetAttributes($current)
+    if (($attributes -band $reparsePoint) -ne 0) {
+      throw "Reparse points are forbidden in sensitive storage paths."
+    }
+  }
+}
+
+function Get-CheckedItems([string]$LiteralPath, [string]$ItemKind) {
+  Assert-NoReparseComponents -LiteralPath $LiteralPath
+  $items = [System.Collections.Generic.List[object]]::new()
+  $pending = [System.Collections.Generic.Stack[object]]::new()
+  $pending.Push([pscustomobject]@{ Path = $LiteralPath; Kind = $ItemKind })
+  while ($pending.Count -gt 0) {
+    $candidate = $pending.Pop()
+    $attributes = [System.IO.File]::GetAttributes($candidate.Path)
+    if (($attributes -band $reparsePoint) -ne 0) {
+      throw "Reparse points are forbidden in sensitive storage trees."
+    }
+    $actualKind = if (($attributes -band $directoryAttribute) -ne 0) { "directory" } else { "file" }
+    if ($actualKind -ne $candidate.Kind) { throw "TargetPath does not match Kind." }
+    $items.Add([pscustomobject]@{ Path = $candidate.Path; Kind = $actualKind })
+    if ($actualKind -eq "directory") {
+      foreach ($child in [System.IO.Directory]::EnumerateFileSystemEntries($candidate.Path)) {
+        $childAttributes = [System.IO.File]::GetAttributes($child)
+        if (($childAttributes -band $reparsePoint) -ne 0) {
+          throw "Reparse points are forbidden in sensitive storage trees."
+        }
+        $childKind = if (($childAttributes -band $directoryAttribute) -ne 0) { "directory" } else { "file" }
+        $pending.Push([pscustomobject]@{ Path = $child; Kind = $childKind })
+      }
+    }
+  }
+  return $items
+}
+
+function Get-ItemAcl([string]$LiteralPath, [string]$ItemKind) {
+  if ($ItemKind -eq "directory") {
+    return [System.IO.Directory]::GetAccessControl($LiteralPath)
+  }
+  return [System.IO.File]::GetAccessControl($LiteralPath)
+}
+
+function Set-ItemAcl([string]$LiteralPath, [string]$ItemKind, $Acl) {
+  if ($ItemKind -eq "directory") {
+    [System.IO.Directory]::SetAccessControl($LiteralPath, $Acl)
+  } else {
+    [System.IO.File]::SetAccessControl($LiteralPath, $Acl)
+  }
+}
+
+function Get-SecurityResult([string]$LiteralPath, [string]$ItemKind, [bool]$RequireProtected) {
   $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
   $systemSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-18")
   $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-544")
-  $allowedSids = @($currentSid.Value, $systemSid.Value, $administratorsSid.Value)
-  if ($ItemKind -eq "directory") {
-    $acl = [System.IO.Directory]::GetAccessControl($LiteralPath)
-  } else {
-    $acl = [System.IO.File]::GetAccessControl($LiteralPath)
-  }
+  $requiredSids = @($currentSid.Value, $systemSid.Value, $administratorsSid.Value)
+  $acl = Get-ItemAcl -LiteralPath $LiteralPath -ItemKind $ItemKind
   $ownerSid = ([System.Security.Principal.NTAccount]$acl.Owner).Translate(
     [System.Security.Principal.SecurityIdentifier]
   ).Value
-  $rules = $acl.GetAccessRules(
+  $rules = @($acl.GetAccessRules(
     $true,
     $true,
     [System.Security.Principal.SecurityIdentifier]
-  )
+  ))
   $unexpectedAllowSids = @(
     $rules |
       Where-Object {
         $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
-        $allowedSids -notcontains $_.IdentityReference.Value
+        $requiredSids -notcontains $_.IdentityReference.Value
       } |
       ForEach-Object { $_.IdentityReference.Value } |
       Sort-Object -Unique
   )
-  $currentUserHasFullControl = @(
-    $rules |
-      Where-Object {
-        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
-        $_.IdentityReference.Value -eq $currentSid.Value -and
-        ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
-          [System.Security.AccessControl.FileSystemRights]::FullControl
-      }
-  ).Count -gt 0
+  $denyRuleCount = @(
+    $rules | Where-Object {
+      $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Deny
+    }
+  ).Count
+  $inheritedRuleCount = @($rules | Where-Object { $_.IsInherited }).Count
+  $missingFullControlSids = @(
+    foreach ($sid in $requiredSids) {
+      $hasUsableFullControl = @(
+        $rules | Where-Object {
+          $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+          $_.IdentityReference.Value -eq $sid -and
+          -not ($_.PropagationFlags -band [System.Security.AccessControl.PropagationFlags]::InheritOnly) -and
+          ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
+            [System.Security.AccessControl.FileSystemRights]::FullControl
+        }
+      ).Count -gt 0
+      if (-not $hasUsableFullControl) { $sid }
+    }
+  )
   $secure =
-    $acl.AreAccessRulesProtected -and
+    ((-not $RequireProtected) -or $acl.AreAccessRulesProtected) -and
     $ownerSid -eq $currentSid.Value -and
     $unexpectedAllowSids.Count -eq 0 -and
-    $currentUserHasFullControl
+    $denyRuleCount -eq 0 -and
+    $missingFullControlSids.Count -eq 0
 
-  [pscustomobject]@{
+  return [pscustomobject]@{
     secure = $secure
     ownerSid = $ownerSid
     inheritanceProtected = $acl.AreAccessRulesProtected
     unexpectedAllowSids = $unexpectedAllowSids
-    currentUserHasFullControl = $currentUserHasFullControl
+    currentUserHasFullControl = $missingFullControlSids -notcontains $currentSid.Value
+    missingFullControlSids = $missingFullControlSids
+    denyRuleCount = $denyRuleCount
+    inheritedRuleCount = $inheritedRuleCount
   }
 }
 
-$resolved = (Resolve-Path -LiteralPath $TargetPath).Path
-$item = Get-Item -LiteralPath $resolved -Force
-if (($Kind -eq "directory") -ne $item.PSIsContainer) {
-  throw "TargetPath does not match Kind."
-}
-
-if ($Mode -eq "apply") {
+function Protect-Item([string]$LiteralPath, [string]$ItemKind) {
   $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
   $systemSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-18")
   $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-544")
-  if ($Kind -eq "directory") {
-    $acl = [System.IO.Directory]::GetAccessControl($resolved)
-  } else {
-    $acl = [System.IO.File]::GetAccessControl($resolved)
-  }
+  $acl = Get-ItemAcl -LiteralPath $LiteralPath -ItemKind $ItemKind
   $acl.SetOwner($currentSid)
   $acl.SetAccessRuleProtection($true, $false)
-  foreach ($rule in @($acl.Access)) {
-    [void]$acl.RemoveAccessRuleAll($rule)
+  $ruleSids = @(
+    $acl.GetAccessRules($true, $false, [System.Security.Principal.SecurityIdentifier]) |
+      ForEach-Object { $_.IdentityReference.Value } |
+      Sort-Object -Unique
+  )
+  foreach ($sidValue in $ruleSids) {
+    $acl.PurgeAccessRules([System.Security.Principal.SecurityIdentifier]::new($sidValue))
   }
-  if ($Kind -eq "directory") {
-    $inheritance =
-      [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+  $inheritance = if ($ItemKind -eq "directory") {
+    [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
       [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
   } else {
-    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+    [System.Security.AccessControl.InheritanceFlags]::None
   }
-  $propagation = [System.Security.AccessControl.PropagationFlags]::None
   foreach ($sid in @($currentSid, $systemSid, $administratorsSid)) {
     $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
       $sid,
       [System.Security.AccessControl.FileSystemRights]::FullControl,
       $inheritance,
-      $propagation,
+      [System.Security.AccessControl.PropagationFlags]::None,
       [System.Security.AccessControl.AccessControlType]::Allow
     )
     [void]$acl.AddAccessRule($rule)
   }
-  if ($Kind -eq "directory") {
-    [System.IO.Directory]::SetAccessControl($resolved, $acl)
-  } else {
-    [System.IO.File]::SetAccessControl($resolved, $acl)
-  }
+  Set-ItemAcl -LiteralPath $LiteralPath -ItemKind $ItemKind -Acl $acl
 }
 
-$result = Get-SecurityResult -LiteralPath $resolved -ItemKind $Kind
-$result | ConvertTo-Json -Compress
-if (-not $result.secure) { exit 3 }
+$fullTarget = [System.IO.Path]::GetFullPath($TargetPath)
+if ($Mode -eq "preflight") {
+  Assert-NoReparseComponents -LiteralPath $fullTarget
+  [pscustomobject]@{
+    secure = $true
+    ownerSid = ""
+    inheritanceProtected = $false
+    unexpectedAllowSids = @()
+    currentUserHasFullControl = $false
+    missingFullControlSids = @()
+    denyRuleCount = 0
+    inheritedRuleCount = 0
+    checkedItemCount = 0
+  } | ConvertTo-Json -Compress
+  exit 0
+}
+$items = @(Get-CheckedItems -LiteralPath $fullTarget -ItemKind $Kind)
+if ($Mode -eq "apply") {
+  foreach ($item in $items) {
+    Protect-Item -LiteralPath $item.Path -ItemKind $item.Kind
+  }
+  $items = @(Get-CheckedItems -LiteralPath $fullTarget -ItemKind $Kind)
+}
+
+$firstFailure = $null
+foreach ($item in $items) {
+  $requireProtected = $item.Path -eq $fullTarget
+  $result = Get-SecurityResult -LiteralPath $item.Path -ItemKind $item.Kind -RequireProtected $requireProtected
+  if (-not $result.secure -and $null -eq $firstFailure) { $firstFailure = $result }
+}
+if ($null -ne $firstFailure) {
+  $firstFailure | Add-Member -NotePropertyName checkedItemCount -NotePropertyValue $items.Count
+  $firstFailure | ConvertTo-Json -Compress
+  exit 3
+}
+
+$success = Get-SecurityResult -LiteralPath $fullTarget -ItemKind $Kind -RequireProtected $true
+$success | Add-Member -NotePropertyName checkedItemCount -NotePropertyValue $items.Count
+$success | ConvertTo-Json -Compress

--- a/scripts/windows-sensitive-path-acl.ps1
+++ b/scripts/windows-sensitive-path-acl.ps1
@@ -1,0 +1,114 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("apply", "verify")]
+  [string]$Mode,
+
+  [Parameter(Mandatory = $true)]
+  [string]$TargetPath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("directory", "file")]
+  [string]$Kind
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-SecurityResult([string]$LiteralPath, [string]$ItemKind) {
+  $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+  $systemSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-18")
+  $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-544")
+  $allowedSids = @($currentSid.Value, $systemSid.Value, $administratorsSid.Value)
+  if ($ItemKind -eq "directory") {
+    $acl = [System.IO.Directory]::GetAccessControl($LiteralPath)
+  } else {
+    $acl = [System.IO.File]::GetAccessControl($LiteralPath)
+  }
+  $ownerSid = ([System.Security.Principal.NTAccount]$acl.Owner).Translate(
+    [System.Security.Principal.SecurityIdentifier]
+  ).Value
+  $rules = $acl.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  )
+  $unexpectedAllowSids = @(
+    $rules |
+      Where-Object {
+        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+        $allowedSids -notcontains $_.IdentityReference.Value
+      } |
+      ForEach-Object { $_.IdentityReference.Value } |
+      Sort-Object -Unique
+  )
+  $currentUserHasFullControl = @(
+    $rules |
+      Where-Object {
+        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+        $_.IdentityReference.Value -eq $currentSid.Value -and
+        ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
+          [System.Security.AccessControl.FileSystemRights]::FullControl
+      }
+  ).Count -gt 0
+  $secure =
+    $acl.AreAccessRulesProtected -and
+    $ownerSid -eq $currentSid.Value -and
+    $unexpectedAllowSids.Count -eq 0 -and
+    $currentUserHasFullControl
+
+  [pscustomobject]@{
+    secure = $secure
+    ownerSid = $ownerSid
+    inheritanceProtected = $acl.AreAccessRulesProtected
+    unexpectedAllowSids = $unexpectedAllowSids
+    currentUserHasFullControl = $currentUserHasFullControl
+  }
+}
+
+$resolved = (Resolve-Path -LiteralPath $TargetPath).Path
+$item = Get-Item -LiteralPath $resolved -Force
+if (($Kind -eq "directory") -ne $item.PSIsContainer) {
+  throw "TargetPath does not match Kind."
+}
+
+if ($Mode -eq "apply") {
+  $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+  $systemSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-18")
+  $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-544")
+  if ($Kind -eq "directory") {
+    $acl = [System.IO.Directory]::GetAccessControl($resolved)
+  } else {
+    $acl = [System.IO.File]::GetAccessControl($resolved)
+  }
+  $acl.SetOwner($currentSid)
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($acl.Access)) {
+    [void]$acl.RemoveAccessRuleAll($rule)
+  }
+  if ($Kind -eq "directory") {
+    $inheritance =
+      [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+      [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  } else {
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+  }
+  $propagation = [System.Security.AccessControl.PropagationFlags]::None
+  foreach ($sid in @($currentSid, $systemSid, $administratorsSid)) {
+    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+      $sid,
+      [System.Security.AccessControl.FileSystemRights]::FullControl,
+      $inheritance,
+      $propagation,
+      [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$acl.AddAccessRule($rule)
+  }
+  if ($Kind -eq "directory") {
+    [System.IO.Directory]::SetAccessControl($resolved, $acl)
+  } else {
+    [System.IO.File]::SetAccessControl($resolved, $acl)
+  }
+}
+
+$result = Get-SecurityResult -LiteralPath $resolved -ItemKind $Kind
+$result | ConvertTo-Json -Compress
+if (-not $result.secure) { exit 3 }


### PR DESCRIPTION
## What changed
- enforce fail-closed Windows ACL validation before startup for configured sensitive stores
- reject reparse-point traversal and recursively verify existing child permissions
- repair permissive child ACLs in apply mode and require usable SYSTEM/Administrators/owner access
- add an operational prestart checker and deployment documentation

## Why
Windows ignores POSIX mode bits, so raw resume and application PII needs explicit NTFS ACL enforcement. The prior implementation also needed junction and inherited-rights defenses.

## Validation
- independent adversarial re-review: APPROVE
- 17 focused ACL tests, including real junction and permissive-child cases
- full suite: 200/200
- lint, typecheck, build: pass
- npm audit: 0 vulnerabilities

## Boundary
This protects a trusted local NTFS filesystem. It does not claim a kernel-atomic snapshot against a hostile process with pre-opened directory handles; post-start ACL drift monitoring remains operational defense in depth.