### PR TITLE
Harden PII protect-mode detection and restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 ## Features
 
 - **Master profile** — paste or upload (PDF / .txt / .md) your resume once, plus an "everything else" field for projects, wins, and metrics that never fit on one page. Auto-saved locally.
+- **Personal-information shield** — locally masks supported contact/identifier forms and an explicitly supplied candidate name before generation, with review and exact-text escape hatches. Its documented limits are in [docs/PII_PROTECTION.md](docs/PII_PROTECTION.md).
 - **Job by URL** — paste a public careers-page link and a bounded HTML response is fetched and extracted server-side. LinkedIn and Indeed automation is rejected; paste those postings manually.
 - **Instant keyword scan** — deterministic, client-side coverage check the moment both fields are filled. Transparent baseline before the AI pass.
 - **AI tailoring** — streaming analysis you can watch live, then: before/after match scores with rationale, classified change log, matched / honestly-added / not-added keywords, gap analysis with concrete advice, and ATS formatting checks.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,9 +52,10 @@ export default function Home() {
   );
 
   // Profile (saved locally, once)
+  const [candidateName, setCandidateName] = useState(() => loadProfile()?.candidateName ?? "");
   const [resume, setResume] = useState(() => loadProfile()?.resume ?? "");
   const [extraInfo, setExtraInfo] = useState(() => loadProfile()?.extraInfo ?? "");
-  const [savedSnapshot, setSavedSnapshot] = useState<{ resume: string; extraInfo: string } | null>(
+  const [savedSnapshot, setSavedSnapshot] = useState<{ candidateName: string; resume: string; extraInfo: string } | null>(
     null,
   );
 
@@ -120,26 +121,26 @@ export default function Home() {
     if (!resume.trim() && !jobText.trim()) return;
     const timer = setTimeout(() => {
       try { setSavePoints(addSavePoint(
-          { resume, extraInfo },
+          { candidateName, resume, extraInfo },
           { jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result },
         )); }
       catch (failure) { reportPersistenceFailure(failure); }
     }, 5000);
     return () => clearTimeout(timer);
-  }, [resume, extraInfo, jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result, reportPersistenceFailure]);
+  }, [candidateName, resume, extraInfo, jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result, reportPersistenceFailure]);
 
   // Debounced autosave of the profile (all setState happens inside the timer callback)
   useEffect(() => {
     const t = setTimeout(() => {
-      try { saveProfile({ resume, extraInfo }); setSavedSnapshot({ resume, extraInfo }); }
+      try { saveProfile({ candidateName, resume, extraInfo }); setSavedSnapshot({ candidateName, resume, extraInfo }); }
       catch (failure) { reportPersistenceFailure(failure); }
     }, 600);
     return () => clearTimeout(t);
-  }, [resume, extraInfo, reportPersistenceFailure]);
+  }, [candidateName, resume, extraInfo, reportPersistenceFailure]);
 
   const profileSaved =
     savedSnapshot === null ||
-    (savedSnapshot.resume === resume && savedSnapshot.extraInfo === extraInfo);
+    (savedSnapshot.candidateName === candidateName && savedSnapshot.resume === resume && savedSnapshot.extraInfo === extraInfo);
 
   // Auto-scroll the live analysis feed
   useEffect(() => {
@@ -207,7 +208,7 @@ export default function Home() {
     const fullResume = extraInfo.trim()
       ? `${resume}\n\n--- Additional background the candidate provided (use as honest evidence, do not print verbatim) ---\n${extraInfo}`
       : resume;
-    const protectedResume = protectPii(fullResume);
+    const protectedResume = protectPii(fullResume, { candidateNames: candidateName ? [candidateName] : [] });
     if (privacyMode === "review" && !privacyOverride && protectedResume.matches.length > 0) {
       setPendingPii(protectedResume.matches);
       return;
@@ -288,7 +289,7 @@ export default function Home() {
       window.clearTimeout(timeout);
       generationAbortRef.current = null;
     }
-  }, [resume, extraInfo, jobText, jobTitle, company, emphasis, privacyMode, reportPersistenceFailure]);
+  }, [candidateName, resume, extraInfo, jobText, jobTitle, company, emphasis, privacyMode, reportPersistenceFailure]);
 
   const cancelGeneration = useCallback(() => {
     cancelReasonRef.current = "cancelled";
@@ -316,6 +317,7 @@ export default function Home() {
       .slice(0, 50) || "tailored";
 
   const restoreSavePoint = useCallback((point: SavePoint) => {
+    setCandidateName(point.profile.candidateName ?? "");
     setResume(point.profile.resume);
     setExtraInfo(point.profile.extraInfo);
     setJobText(point.session.jobText);
@@ -332,12 +334,12 @@ export default function Home() {
   const createManualSavePoint = useCallback(() => {
     try {
       setSavePoints(addSavePoint(
-        { resume, extraInfo },
+        { candidateName, resume, extraInfo },
         { jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result },
         "Manual save point",
       ));
     } catch (failure) { reportPersistenceFailure(failure); }
-  }, [resume, extraInfo, jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result, reportPersistenceFailure]);
+  }, [candidateName, resume, extraInfo, jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result, reportPersistenceFailure]);
 
   return (
     <div className="mx-auto max-w-6xl px-4 pb-24 pt-10 md:px-8">
@@ -380,6 +382,27 @@ export default function Home() {
             title="Your profile"
             hint={profileSaved ? "saved locally ✓" : "saving…"}
           >
+            <div className="mb-4 max-w-md">
+              <label htmlFor="candidate-name" className="mb-1 block text-xs text-ink-300">
+                Your name for privacy protection
+              </label>
+              <input
+                id="candidate-name"
+                type="text"
+                autoComplete="name"
+                maxLength={120}
+                value={candidateName}
+                onChange={(event) => {
+                  invalidateResult();
+                  setCandidateName(event.target.value);
+                }}
+                placeholder="Jane Doe"
+                className="w-full rounded-lg border border-ink-700 bg-ink-950/80 px-3 py-2 text-sm text-ink-100 outline-none transition focus:border-brass-400/60"
+              />
+              <p className="mt-1 text-[10px] leading-snug text-ink-400">
+                Optional. Protect mode masks this exact name locally; it never guesses which words are a person’s name.
+              </p>
+            </div>
             <div className="grid gap-4 md:grid-cols-[2fr_1fr]">
               <div>
                 <div className="mb-2 flex items-center justify-between">
@@ -610,8 +633,9 @@ export default function Home() {
             <div>
               <h2 className="text-sm font-semibold text-paper">Personal information shield</h2>
               <p className="mt-1 max-w-2xl text-[11px] leading-relaxed text-ink-400">
-                Contact details are replaced locally before generation and restored afterward. You
-                can review detected fields or send your exact text whenever you choose.
+                Contact details and the name you explicitly enter above are replaced locally before
+                generation and restored afterward. Names are never guessed. You can review detected
+                fields or send your exact text whenever you choose.
               </p>
               <p className="mt-1 max-w-2xl text-[10px] leading-relaxed text-ink-400">
                 Read-aloud uses your browser/device voice. Dictation starts only when you press its
@@ -631,8 +655,8 @@ export default function Home() {
           </div>
           {privacyMode === "exact" && (
             <p role="status" className="mt-3 text-xs text-warn">
-              Exact mode may send email addresses, phone numbers, profile links, addresses, or other
-              identifiers to Anthropic. You can switch back at any time.
+              Exact mode may send your name, email addresses, phone numbers, profile links,
+              addresses, or other identifiers to Anthropic. You can switch back at any time.
             </p>
           )}
         </div>
@@ -801,7 +825,7 @@ export default function Home() {
                 onClick={async () => {
                   if (confirm("Delete your saved profile and all history from this browser?")) {
                     try {
-                      await clearAllData(); setHistory([]); setSavePoints([]); setResume(""); setExtraInfo("");
+                      await clearAllData(); setHistory([]); setSavePoints([]); setCandidateName(""); setResume(""); setExtraInfo("");
                     } catch (failure) { reportPersistenceFailure(failure); }
                   }
                 }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -824,9 +824,9 @@ export default function Home() {
               <ToolButton
                 onClick={async () => {
                   if (confirm("Delete your saved profile and all history from this browser?")) {
-                    try {
-                      await clearAllData(); setHistory([]); setSavePoints([]); setCandidateName(""); setResume(""); setExtraInfo("");
-                    } catch (failure) { reportPersistenceFailure(failure); }
+                    try { await clearAllData(); }
+                    catch (failure) { reportPersistenceFailure(failure); }
+                    finally { setHistory([]); setSavePoints([]); setCandidateName(""); setResume(""); setExtraInfo(""); }
                   }
                 }}
               >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -260,8 +260,13 @@ export default function Home() {
     generationAbortRef.current = controller;
     cancelReasonRef.current = null;
     const timeout = window.setTimeout(() => {
+      if (generationId !== activeGenerationRef.current) return;
       cancelReasonRef.current = "timeout";
+      activeGenerationRef.current += 1;
+      generationAbortRef.current = null;
       controller.abort();
+      setError("Generation timed out after three minutes. Your inputs are safe; retry when ready.");
+      setPhase("error");
     }, GENERATION_TIMEOUT_MS);
     setPhase("working");
     setThinking("");
@@ -338,8 +343,14 @@ export default function Home() {
   }, [candidateName, resume, extraInfo, jobText, jobTitle, company, emphasis, privacyMode, reportPersistenceFailure]);
 
   const cancelGeneration = useCallback(() => {
+    const controller = generationAbortRef.current;
+    if (!controller) return;
     cancelReasonRef.current = "cancelled";
-    generationAbortRef.current?.abort();
+    activeGenerationRef.current += 1;
+    generationAbortRef.current = null;
+    controller.abort();
+    setError("Generation cancelled. Your inputs are safe and unchanged.");
+    setPhase("error");
   }, []);
 
   const clearJob = useCallback(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,22 +88,60 @@ export default function Home() {
   const resultRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const forgeButtonRef = useRef<HTMLButtonElement>(null);
+  const pageRef = useRef<HTMLDivElement>(null);
+  const reviewDialogRef = useRef<HTMLDivElement>(null);
+  const protectedChoiceRef = useRef<HTMLButtonElement>(null);
   const restoreForgeFocusRef = useRef(false);
   const generationAbortRef = useRef<AbortController | null>(null);
+  const activeGenerationRef = useRef(0);
   const cancelReasonRef = useRef<"cancelled" | "timeout" | null>(null);
   const reportPersistenceFailure = useCallback((failure: unknown) => {
     setNotice(failure instanceof Error ? failure.message : "Browser storage failed. Your latest changes may not survive a reload.");
   }, []);
 
   useEffect(() => {
-    if (pendingPii.length === 0 && restoreForgeFocusRef.current) {
+    if (pendingPii.length === 0 && phase !== "working" && restoreForgeFocusRef.current) {
       restoreForgeFocusRef.current = false;
       forgeButtonRef.current?.focus();
     }
+  }, [pendingPii, phase]);
+
+  const closePiiReview = useCallback(() => {
+    restoreForgeFocusRef.current = true;
+    setPendingPii([]);
+  }, []);
+
+  useEffect(() => {
+    if (pendingPii.length === 0) return;
+    const dialog = reviewDialogRef.current;
+    const container = dialog?.parentElement;
+    const page = pageRef.current;
+    if (!dialog || !container || !page) return;
+    const siblings = [...new Set([
+      ...Array.from(container.children).filter((child): child is HTMLElement => child instanceof HTMLElement && child !== dialog),
+      ...Array.from(page.children).filter((child): child is HTMLElement => child instanceof HTMLElement && !child.contains(dialog)),
+    ])];
+    const previous = siblings.map((element) => ({ element, inert: element.inert, ariaHidden: element.getAttribute("aria-hidden") }));
+    for (const element of siblings) {
+      element.inert = true;
+      element.setAttribute("aria-hidden", "true");
+    }
+    protectedChoiceRef.current?.focus();
+    return () => {
+      for (const { element, inert, ariaHidden } of previous) {
+        element.inert = inert;
+        if (ariaHidden === null) element.removeAttribute("aria-hidden");
+        else element.setAttribute("aria-hidden", ariaHidden);
+      }
+    };
   }, [pendingPii]);
 
   const invalidateResult = useCallback(() => {
-    if (!result) return;
+    const hadActiveGeneration = generationAbortRef.current !== null;
+    activeGenerationRef.current += 1;
+    generationAbortRef.current?.abort();
+    generationAbortRef.current = null;
+    if (!result && !hadActiveGeneration) return;
     setResult(null);
     setPhase("idle");
     setNotice("Inputs changed — the previous generated result remains in Past runs, but is no longer active.");
@@ -218,6 +256,7 @@ export default function Home() {
     const restorationMap = sendProtected ? protectedResume.matches : [];
     setPendingPii([]);
     const controller = new AbortController();
+    const generationId = ++activeGenerationRef.current;
     generationAbortRef.current = controller;
     cancelReasonRef.current = null;
     const timeout = window.setTimeout(() => {
@@ -264,6 +303,7 @@ export default function Home() {
           else if (event.type === "progress") setProgressChars(event.chars);
           else if (event.type === "error") throw new Error(event.message);
           else if (event.type === "result") {
+            if (generationId !== activeGenerationRef.current) return;
             const restoredResult = restorePii(event.data, restorationMap);
             setResult(restoredResult);
             try { setHistory(addHistory({ jobTitle, company, result: restoredResult })); }
@@ -276,6 +316,7 @@ export default function Home() {
       if (!finished) throw new Error("The stream ended unexpectedly. Try again.");
       setTimeout(() => resultRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 80);
     } catch (err) {
+      if (generationId !== activeGenerationRef.current) return;
       const cancelled = controller.signal.aborted;
       setError(
         cancelled
@@ -287,7 +328,7 @@ export default function Home() {
       setPhase("error");
     } finally {
       window.clearTimeout(timeout);
-      generationAbortRef.current = null;
+      if (generationId === activeGenerationRef.current) generationAbortRef.current = null;
     }
   }, [candidateName, resume, extraInfo, jobText, jobTitle, company, emphasis, privacyMode, reportPersistenceFailure]);
 
@@ -297,7 +338,7 @@ export default function Home() {
   }, []);
 
   const clearJob = useCallback(() => {
-    generationAbortRef.current?.abort();
+    invalidateResult();
     setJobUrl("");
     setJobText("");
     setJobTitle("");
@@ -306,7 +347,7 @@ export default function Home() {
     setResult(null);
     setPhase("idle");
     setNotice("Job fields cleared.");
-  }, []);
+  }, [invalidateResult]);
 
   const ready = resume.length >= 200 && jobText.length >= 100 && phase !== "working";
   const slug =
@@ -317,6 +358,7 @@ export default function Home() {
       .slice(0, 50) || "tailored";
 
   const restoreSavePoint = useCallback((point: SavePoint) => {
+    invalidateResult();
     setCandidateName(point.profile.candidateName ?? "");
     setResume(point.profile.resume);
     setExtraInfo(point.profile.extraInfo);
@@ -329,7 +371,7 @@ export default function Home() {
     setResult(point.session.result);
     setPhase(point.session.result ? "done" : "idle");
     setNotice(`Restored save point from ${new Date(point.createdAt).toLocaleString()}.`);
-  }, []);
+  }, [invalidateResult]);
 
   const createManualSavePoint = useCallback(() => {
     try {
@@ -342,7 +384,7 @@ export default function Home() {
   }, [candidateName, resume, extraInfo, jobText, jobUrl, jobTitle, company, emphasis, privacyMode, result, reportPersistenceFailure]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 pb-24 pt-10 md:px-8">
+    <div ref={pageRef} className="mx-auto max-w-6xl px-4 pb-24 pt-10 md:px-8">
       {/* Masthead */}
       <header className="rise mb-10 border-b border-ink-700 pb-8">
         <div className="flex flex-wrap items-end justify-between gap-4">
@@ -645,7 +687,7 @@ export default function Home() {
             <select
               aria-label="Personal information protection mode"
               value={privacyMode}
-              onChange={(event) => setPrivacyMode(event.target.value as PrivacyMode)}
+              onChange={(event) => { invalidateResult(); setPrivacyMode(event.target.value as PrivacyMode); }}
               className="rounded-lg border border-ink-700 bg-ink-950 px-3 py-2 text-xs text-ink-100"
             >
               <option value="protect">Protect automatically</option>
@@ -662,18 +704,40 @@ export default function Home() {
         </div>
 
         {pendingPii.length > 0 && (
-          <div role="alertdialog" aria-label="Review personal information" className="rounded-xl border border-warn/50 bg-warn/10 p-4">
-            <h2 className="font-semibold text-paper">Review before anything leaves this browser</h2>
+          <div
+            ref={reviewDialogRef}
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="pii-review-title"
+            className="rounded-xl border border-warn/50 bg-warn/10 p-4"
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                closePiiReview();
+                return;
+              }
+              if (event.key !== "Tab") return;
+              const controls = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("button:not(:disabled)"));
+              if (controls.length === 0) return;
+              const first = controls[0];
+              const last = controls.at(-1)!;
+              if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+              } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+              }
+            }}
+          >
+            <h2 id="pii-review-title" className="font-semibold text-paper">Review before anything leaves this browser</h2>
             <p className="mt-1 text-xs text-ink-300">
               Found {pendingPii.length} personal field{pendingPii.length === 1 ? "" : "s"}: {Array.from(new Set(pendingPii.map((match) => match.kind))).join(", ")}.
             </p>
             <div className="mt-3 flex flex-wrap gap-2">
-              <ToolButton onClick={() => void forge("protected")}>Send protected copy</ToolButton>
-              <ToolButton onClick={() => void forge("exact")}>Send exact text once</ToolButton>
-              <ToolButton onClick={() => {
-                restoreForgeFocusRef.current = true;
-                setPendingPii([]);
-              }}>Cancel</ToolButton>
+              <ToolButton ref={protectedChoiceRef} onClick={() => { restoreForgeFocusRef.current = true; void forge("protected"); }}>Send protected copy</ToolButton>
+              <ToolButton onClick={() => { restoreForgeFocusRef.current = true; void forge("exact"); }}>Send exact text once</ToolButton>
+              <ToolButton onClick={closePiiReview}>Cancel</ToolButton>
             </div>
           </div>
         )}
@@ -815,25 +879,32 @@ export default function Home() {
           )}
         </section>
 
-        {history.length > 0 && (
-          <section className="mt-10 border-t border-ink-700 pt-6">
+        <section className="mt-10 border-t border-ink-700 pt-6">
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-sm font-semibold tracking-wide text-paper">
                 Past runs <span className="text-ink-400">(stored only in this browser)</span>
               </h2>
               <ToolButton
                 onClick={async () => {
-                  if (confirm("Delete your saved profile and all history from this browser?")) {
+                  if (confirm("Delete all your saved Resume Foundry data from this browser?")) {
+                    activeGenerationRef.current += 1;
+                    generationAbortRef.current?.abort();
+                    generationAbortRef.current = null;
                     try { await clearAllData(); }
                     catch (failure) { reportPersistenceFailure(failure); }
-                    finally { setHistory([]); setSavePoints([]); setCandidateName(""); setResume(""); setExtraInfo(""); }
+                    finally {
+                      setHistory([]); setSavePoints([]); setCandidateName(""); setResume(""); setExtraInfo("");
+                      setJobText(""); setJobUrl(""); setJobTitle(""); setCompany(""); setEmphasis("balanced");
+                      setPrivacyMode("protect"); setPendingPii([]); setResult(null); setPhase("idle");
+                      setThinking(""); setProgressChars(0); setError("");
+                    }
                   }
                 }}
               >
                 Erase all my data
               </ToolButton>
             </div>
-            <ul className="grid gap-2 md:grid-cols-2">
+            {history.length > 0 && <ul className="grid gap-2 md:grid-cols-2">
               {history.map((h) => (
                 <li
                   key={h.id}
@@ -872,9 +943,8 @@ export default function Home() {
                   </button>
                 </li>
               ))}
-            </ul>
+            </ul>}
           </section>
-        )}
       </main>
       )}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -299,11 +299,11 @@ export default function Home() {
             | { type: "progress"; chars: number }
             | { type: "result"; data: TailorResult }
             | { type: "error"; message: string };
+          if (generationId !== activeGenerationRef.current) return;
           if (event.type === "thinking") setThinking((t) => t + event.text);
           else if (event.type === "progress") setProgressChars(event.chars);
           else if (event.type === "error") throw new Error(event.message);
           else if (event.type === "result") {
-            if (generationId !== activeGenerationRef.current) return;
             const restoredResult = restorePii(event.data, restorationMap);
             setResult(restoredResult);
             try { setHistory(addHistory({ jobTitle, company, result: restoredResult })); }
@@ -314,7 +314,12 @@ export default function Home() {
         }
       }
       if (!finished) throw new Error("The stream ended unexpectedly. Try again.");
-      setTimeout(() => resultRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 80);
+      if (generationId !== activeGenerationRef.current) return;
+      setTimeout(() => {
+        if (generationId === activeGenerationRef.current) {
+          resultRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      }, 80);
     } catch (err) {
       if (generationId !== activeGenerationRef.current) return;
       const cancelled = controller.signal.aborted;

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 
 export function Section({
   step,
@@ -98,17 +98,18 @@ export function CopyButton({ text, label = "Copy" }: { text: string; label?: str
   );
 }
 
-export function ToolButton({
-  onClick,
-  children,
-  disabled,
-}: {
+export const ToolButton = forwardRef<HTMLButtonElement, {
   onClick: () => void;
   children: React.ReactNode;
   disabled?: boolean;
-}) {
+}>(function ToolButton({
+  onClick,
+  children,
+  disabled,
+}, ref) {
   return (
     <button
+      ref={ref}
       type="button"
       onClick={onClick}
       disabled={disabled}
@@ -117,7 +118,7 @@ export function ToolButton({
       {children}
     </button>
   );
-}
+});
 
 export function Spinner() {
   return (

--- a/docs/PII_PROTECTION.md
+++ b/docs/PII_PROTECTION.md
@@ -5,7 +5,8 @@ the tailoring request is sent, then restores those exact values in the returned
 document. **Review** mode shows the detected categories before the user chooses
 protected or exact transmission. **Exact** mode sends the text as entered.
 
-The detector covers email addresses, LinkedIn, GitHub, and GitLab profile URLs, common US
+The detector covers email addresses, LinkedIn `/in/{user}` profiles and root
+GitHub/GitLab user profiles (not repository or group URLs), common US
 street-address forms, dashed/spaced/compact US SSN-shaped identifiers, common
 US phone forms, and `+`-prefixed international numbers containing 8–15 digits.
 The user can also enter their own name explicitly; only that supplied value is
@@ -21,3 +22,10 @@ guessed to be personal profiles; users should inspect them in Review mode or
 remove them manually when needed. Review mode is the appropriate choice when the
 user wants to inspect detections; Exact mode remains an explicit escape hatch.
 No mode changes the underlying browser-local saved profile.
+
+Protected placeholders use a fresh random namespace for each run. Restoration
+prioritizes the tailored résumé before the cover letter and then uses stable
+field ordering. It restores no more occurrences than existed in the submitted
+source; an unexpected model-added repetition becomes an explicit
+`Personal information withheld` marker instead of inserting extra PII or
+leaking an internal placeholder.

--- a/docs/PII_PROTECTION.md
+++ b/docs/PII_PROTECTION.md
@@ -5,7 +5,7 @@ the tailoring request is sent, then restores those exact values in the returned
 document. **Review** mode shows the detected categories before the user chooses
 protected or exact transmission. **Exact** mode sends the text as entered.
 
-The detector covers email addresses, LinkedIn and other profile URLs, common US
+The detector covers email addresses, LinkedIn, GitHub, and GitLab profile URLs, common US
 street-address forms, dashed/spaced/compact US SSN-shaped identifiers, common
 US phone forms, and `+`-prefixed international numbers containing 8–15 digits.
 The user can also enter their own name explicitly; only that supplied value is
@@ -16,6 +16,8 @@ employers, references, products, and places.
 This is a data-minimization aid, not a general data-loss-prevention guarantee.
 National phone and identifier formats vary, compact nine-digit values can be
 ambiguous, addresses outside the covered forms may be missed, and text can
-contain other sensitive facts. Review mode is the appropriate choice when the
+contain other sensitive facts. Generic portfolio and project URLs are not
+guessed to be personal profiles; users should inspect them in Review mode or
+remove them manually when needed. Review mode is the appropriate choice when the
 user wants to inspect detections; Exact mode remains an explicit escape hatch.
 No mode changes the underlying browser-local saved profile.

--- a/docs/PII_PROTECTION.md
+++ b/docs/PII_PROTECTION.md
@@ -1,0 +1,21 @@
+# Personal-information protection boundary
+
+Resume Foundry's **Protect** mode replaces detected values in the browser before
+the tailoring request is sent, then restores those exact values in the returned
+document. **Review** mode shows the detected categories before the user chooses
+protected or exact transmission. **Exact** mode sends the text as entered.
+
+The detector covers email addresses, LinkedIn and other profile URLs, common US
+street-address forms, dashed/spaced/compact US SSN-shaped identifiers, common
+US phone forms, and `+`-prefixed international numbers containing 8–15 digits.
+The user can also enter their own name explicitly; only that supplied value is
+masked. The product does not guess personal names from arbitrary prose because
+doing so is neither culturally complete nor reliably distinguishable from
+employers, references, products, and places.
+
+This is a data-minimization aid, not a general data-loss-prevention guarantee.
+National phone and identifier formats vary, compact nine-digit values can be
+ambiguous, addresses outside the covered forms may be missed, and text can
+contain other sensitive facts. Review mode is the appropriate choice when the
+user wants to inspect detections; Exact mode remains an explicit escape hatch.
+No mode changes the underlying browser-local saved profile.

--- a/lib/pii-outbound-flow.test.ts
+++ b/lib/pii-outbound-flow.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"http://localhost/"}
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deleteCareerLedgerMock } = vi.hoisted(() => ({ deleteCareerLedgerMock: vi.fn(async () => undefined) }));
+vi.mock("@/lib/career-vault", () => ({ deleteCareerLedger: deleteCareerLedgerMock }));
+
+vi.mock("@/components/ResultView", () => ({ ResultView: () => null }));
+vi.mock("@/components/SpeechControls", () => ({ DictationButton: () => null }));
+vi.mock("@/components/JobInbox", () => ({ JobInbox: () => null }));
+vi.mock("@/components/ApplicationTracker", () => ({ ApplicationTracker: () => null }));
+vi.mock("@/components/CareerLedger", () => ({ CareerLedger: () => null }));
+vi.mock("@/components/Connections", () => ({ Connections: () => null }));
+vi.mock("@/components/SensitiveAttestationBoundary", () => ({ SensitiveAttestationBoundary: () => null }));
+vi.mock("@/components/ui", async () => {
+  const ReactModule = await import("react");
+  return {
+    Chip: ({ children }: { children?: React.ReactNode }) => ReactModule.createElement("span", null, children),
+    Section: ({ children, title }: { children?: React.ReactNode; title?: string }) =>
+      ReactModule.createElement("section", null, ReactModule.createElement("h2", null, title), children),
+    Spinner: () => ReactModule.createElement("span", null, "loading"),
+    ToolButton: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+      ReactModule.createElement("button", { type: "button", ...props }, children),
+  };
+});
+
+import Home from "@/app/page";
+
+const resume = `Jane Doe\nJane@example.com\n${"Experienced engineer delivering reliable systems. ".repeat(6)}`;
+const job = "Build and operate reliable systems with testing, security, documentation, collaboration, and customer focus. ".repeat(2);
+
+function setValue(element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, value: string) {
+  const prototype = element instanceof HTMLSelectElement ? HTMLSelectElement.prototype
+    : element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(prototype, "value")?.set?.call(element, value);
+  element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? "change" : "input", { bubbles: true }));
+}
+
+function button(label: string): HTMLButtonElement {
+  const match = Array.from(document.querySelectorAll("button")).find((item) => item.textContent?.includes(label));
+  if (!(match instanceof HTMLButtonElement)) throw new Error(`Missing button: ${label}`);
+  return match;
+}
+
+describe("real browser outbound PII flow", () => {
+  let root: Root;
+  let requests: Array<Record<string, unknown>>;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    requests = [];
+    deleteCareerLedgerMock.mockReset();
+    deleteCareerLedgerMock.mockResolvedValue(undefined);
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(`${JSON.stringify({ type: "result", data: {} })}\n`));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }));
+    root = createRoot(document.body.appendChild(document.createElement("div")));
+    await act(async () => { root.render(React.createElement(Home)); });
+    await act(async () => {
+      setValue(document.querySelector("#candidate-name") as HTMLInputElement, "Jane Doe");
+      setValue(document.querySelector("#resume") as HTMLTextAreaElement, resume);
+      setValue(document.querySelector("#job-description") as HTMLTextAreaElement, job);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it("protect mode sends the outbound request without the explicit name or contact data", async () => {
+    await act(async () => button("Forge my resume").click());
+    expect(requests).toHaveLength(1);
+    const outbound = String(requests[0].resume);
+    expect(outbound).not.toMatch(/Jane Doe|Jane@example\.com/i);
+    expect(outbound).toMatch(/\[\[RF_[a-f0-9]{32}_CANDIDATE_NAME_1\]\]/);
+  });
+
+  it("review mode sends nothing until the user chooses protected or exact transmission", async () => {
+    await act(async () => setValue(
+      document.querySelector('[aria-label="Personal information protection mode"]') as HTMLSelectElement,
+      "review",
+    ));
+    await act(async () => button("Forge my resume").click());
+    expect(requests).toHaveLength(0);
+    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
+
+    await act(async () => button("Send protected copy").click());
+    expect(requests).toHaveLength(1);
+    expect(String(requests[0].resume)).not.toMatch(/Jane Doe|Jane@example\.com/i);
+  });
+
+  it("review mode sends exact text only after the explicit one-time choice", async () => {
+    await act(async () => setValue(
+      document.querySelector('[aria-label="Personal information protection mode"]') as HTMLSelectElement,
+      "review",
+    ));
+    await act(async () => button("Forge my resume").click());
+    await act(async () => button("Send exact text once").click());
+    expect(requests).toHaveLength(1);
+    expect(String(requests[0].resume)).toContain("Jane Doe");
+    expect(String(requests[0].resume)).toContain("Jane@example.com");
+  });
+
+  it("clears visible PII even when encrypted-vault deletion reports a failure", async () => {
+    await act(async () => root.unmount());
+    document.body.replaceChildren();
+    localStorage.clear();
+    localStorage.setItem("art:profile", JSON.stringify({ candidateName: "Jane Doe", resume, extraInfo: "private", updatedAt: 1 }));
+    localStorage.setItem("art:history", JSON.stringify([{
+      id: "history-1", createdAt: 1, jobTitle: "Engineer", company: "Example",
+      result: {
+        match_score_before: 1, match_score_after: 2, score_rationale: "Evidence",
+        changes: [], keywords: { matched: [], added: [], not_added: [] }, gap_analysis: [],
+        requirement_evidence: [], ats_checks: [], tailored_resume_markdown: "Resume", cover_letter_markdown: "Letter",
+      },
+    }]));
+    deleteCareerLedgerMock.mockRejectedValueOnce(new Error("vault unavailable"));
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    root = createRoot(document.body.appendChild(document.createElement("div")));
+    await act(async () => { root.render(React.createElement(Home)); });
+    expect((document.querySelector("#candidate-name") as HTMLInputElement).value).toBe("Jane Doe");
+
+    await act(async () => button("Erase all my data").click());
+    expect((document.querySelector("#candidate-name") as HTMLInputElement).value).toBe("");
+    expect((document.querySelector("#resume") as HTMLTextAreaElement).value).toBe("");
+    expect(localStorage.getItem("art:profile")).toBeNull();
+    expect(document.body.textContent).toContain("Browser storage failed while erasing the encrypted career ledger");
+  });
+});

--- a/lib/pii-outbound-flow.test.ts
+++ b/lib/pii-outbound-flow.test.ts
@@ -52,6 +52,7 @@ describe("real browser outbound PII flow", () => {
   beforeEach(async () => {
     localStorage.clear();
     HTMLElement.prototype.scrollTo = vi.fn();
+    HTMLElement.prototype.scrollIntoView = vi.fn();
     requests = [];
     deleteCareerLedgerMock.mockReset();
     deleteCareerLedgerMock.mockResolvedValue(undefined);
@@ -184,6 +185,78 @@ describe("real browser outbound PII flow", () => {
       currentController.error(new DOMException("cancelled", "AbortError"));
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
+  });
+
+  it.each([
+    ["thinking", { type: "thinking", text: "LATE CANCELLED ANALYSIS" }],
+    ["progress", { type: "progress", chars: 999 }],
+    ["error", { type: "error", message: "late cancelled error" }],
+    ["result", {
+      type: "result",
+      data: {
+        match_score_before: 1, match_score_after: 2, score_rationale: "Late cancelled result",
+        changes: [], keywords: { matched: [], added: [], not_added: [] }, gap_analysis: [],
+        requirement_evidence: [], ats_checks: [], tailored_resume_markdown: "Late cancelled resume",
+        cover_letter_markdown: "Late cancelled letter",
+      },
+    }],
+  ])("ignores a late %s event when cancellation is ignored by the stream", async (_type, event) => {
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    vi.mocked(fetch).mockImplementationOnce(async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(new ReadableStream({ start(controller) { streamController = controller; } }), { status: 200 });
+    });
+
+    await act(async () => { button("Forge my resume").click(); });
+    await act(async () => { button("Cancel generation").click(); });
+    expect(document.body.textContent).toContain("Generation cancelled");
+
+    await act(async () => {
+      streamController.enqueue(new TextEncoder().encode(`${JSON.stringify(event)}\n`));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(document.body.textContent).not.toContain("LATE CANCELLED ANALYSIS");
+    expect(document.body.textContent).not.toContain("999 chars");
+    expect(document.body.textContent).not.toContain("late cancelled error");
+    expect(document.body.textContent).not.toContain("Late cancelled resume");
+    expect(JSON.parse(localStorage.getItem("art:history") ?? "[]")).toEqual([]);
+    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("times out immediately in the UI and ignores a late result when abort is ignored", async () => {
+    vi.useFakeTimers();
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    vi.mocked(fetch).mockImplementationOnce(async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(new ReadableStream({ start(controller) { streamController = controller; } }), { status: 200 });
+    });
+    const lateResult = {
+      type: "result",
+      data: {
+        match_score_before: 1, match_score_after: 2, score_rationale: "Late timeout result",
+        changes: [], keywords: { matched: [], added: [], not_added: [] }, gap_analysis: [],
+        requirement_evidence: [], ats_checks: [], tailored_resume_markdown: "Late timeout resume",
+        cover_letter_markdown: "Late timeout letter",
+      },
+    };
+
+    try {
+      await act(async () => { button("Forge my resume").click(); });
+      await act(async () => { vi.advanceTimersByTime(180_000); });
+      expect(document.body.textContent).toContain("Generation timed out after three minutes");
+
+      await act(async () => {
+        streamController.enqueue(new TextEncoder().encode(`${JSON.stringify(lateResult)}\n`));
+        await vi.runAllTimersAsync();
+      });
+
+      expect(document.body.textContent).not.toContain("Late timeout resume");
+      expect(JSON.parse(localStorage.getItem("art:history") ?? "[]")).toEqual([]);
+      expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("makes erase-all reachable when a profile exists without history", async () => {

--- a/lib/pii-outbound-flow.test.ts
+++ b/lib/pii-outbound-flow.test.ts
@@ -125,6 +125,69 @@ describe("real browser outbound PII flow", () => {
     expect(String(requests[0].resume)).toContain("Jane@example.com");
   });
 
+  it("discards an in-flight result when a bound input changes", async () => {
+    let release!: () => void;
+    const responseReady = new Promise<void>((resolve) => { release = resolve; });
+    vi.mocked(fetch).mockImplementationOnce(async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      await responseReady;
+      const result = {
+        match_score_before: 1, match_score_after: 2, score_rationale: "Stale result",
+        changes: [], keywords: { matched: [], added: [], not_added: [] }, gap_analysis: [],
+        requirement_evidence: [], ats_checks: [], tailored_resume_markdown: "Stale resume", cover_letter_markdown: "Stale letter",
+      };
+      const stream = new ReadableStream({ start(controller) {
+        controller.enqueue(new TextEncoder().encode(`${JSON.stringify({ type: "result", data: result })}\n`));
+        controller.close();
+      } });
+      return new Response(stream, { status: 200 });
+    });
+
+    await act(async () => { button("Forge my resume").click(); });
+    await act(async () => setValue(document.querySelector("#resume") as HTMLTextAreaElement, `${resume} changed`));
+    await act(async () => { release(); await responseReady; });
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+
+    expect(document.body.textContent).not.toContain("Stale resume");
+    expect(JSON.parse(localStorage.getItem("art:history") ?? "[]")).toEqual([]);
+    expect(document.body.textContent).toContain("Inputs changed");
+  });
+
+  it("makes erase-all reachable when a profile exists without history", async () => {
+    await act(async () => root.unmount());
+    document.body.replaceChildren();
+    localStorage.clear();
+    localStorage.setItem("art:profile", JSON.stringify({ candidateName: "Jane Doe", resume, extraInfo: "private", updatedAt: 1 }));
+    root = createRoot(document.body.appendChild(document.createElement("div")));
+    await act(async () => { root.render(React.createElement(Home)); });
+    expect(button("Erase all my data")).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it("focuses and contains the review dialog, cancels with Escape, and restores Forge focus", async () => {
+    await act(async () => setValue(
+      document.querySelector('[aria-label="Personal information protection mode"]') as HTMLSelectElement,
+      "review",
+    ));
+    const forge = button("Forge my resume");
+    forge.focus();
+    await act(async () => forge.click());
+    const dialog = document.querySelector('[role="alertdialog"]') as HTMLElement;
+    const protectedButton = button("Send protected copy");
+    const cancelButton = button("Cancel");
+    expect(document.activeElement).toBe(protectedButton);
+    expect(Array.from(dialog.parentElement?.children ?? []).filter((node) => node !== dialog).every((node) => (node as HTMLElement).inert)).toBe(true);
+
+    cancelButton.focus();
+    cancelButton.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(document.activeElement).toBe(protectedButton);
+    protectedButton.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }));
+    expect(document.activeElement).toBe(cancelButton);
+
+    await act(async () => protectedButton.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+    expect(document.activeElement).toBe(forge);
+  });
+
   it("clears visible PII even when encrypted-vault deletion reports a failure", async () => {
     await act(async () => root.unmount());
     document.body.replaceChildren();

--- a/lib/pii-outbound-flow.test.ts
+++ b/lib/pii-outbound-flow.test.ts
@@ -113,6 +113,18 @@ describe("real browser outbound PII flow", () => {
     expect(String(requests[0].resume)).toContain("Jane@example.com");
   });
 
+  it("Exact mode directly sends the exact text without opening review", async () => {
+    await act(async () => setValue(
+      document.querySelector('[aria-label="Personal information protection mode"]') as HTMLSelectElement,
+      "exact",
+    ));
+    await act(async () => button("Forge my resume").click());
+    expect(requests).toHaveLength(1);
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+    expect(String(requests[0].resume)).toContain("Jane Doe");
+    expect(String(requests[0].resume)).toContain("Jane@example.com");
+  });
+
   it("clears visible PII even when encrypted-vault deletion reports a failure", async () => {
     await act(async () => root.unmount());
     document.body.replaceChildren();

--- a/lib/pii-outbound-flow.test.ts
+++ b/lib/pii-outbound-flow.test.ts
@@ -51,6 +51,7 @@ describe("real browser outbound PII flow", () => {
 
   beforeEach(async () => {
     localStorage.clear();
+    HTMLElement.prototype.scrollTo = vi.fn();
     requests = [];
     deleteCareerLedgerMock.mockReset();
     deleteCareerLedgerMock.mockResolvedValue(undefined);
@@ -151,6 +152,38 @@ describe("real browser outbound PII flow", () => {
     expect(document.body.textContent).not.toContain("Stale resume");
     expect(JSON.parse(localStorage.getItem("art:history") ?? "[]")).toEqual([]);
     expect(document.body.textContent).toContain("Inputs changed");
+  });
+
+  it("ignores late analysis events from a stream that continues after input invalidation", async () => {
+    let staleController!: ReadableStreamDefaultController<Uint8Array>;
+    let currentController!: ReadableStreamDefaultController<Uint8Array>;
+    vi.mocked(fetch)
+      .mockImplementationOnce(async (_url, init) => {
+        requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(new ReadableStream({ start(controller) { staleController = controller; } }), { status: 200 });
+      })
+      .mockImplementationOnce(async (_url, init) => {
+        requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(new ReadableStream({ start(controller) { currentController = controller; } }), { status: 200 });
+      });
+
+    await act(async () => { button("Forge my resume").click(); });
+    await act(async () => setValue(document.querySelector("#resume") as HTMLTextAreaElement, `${resume} changed`));
+    await act(async () => { button("Forge my resume").click(); });
+    await act(async () => {
+      staleController.enqueue(new TextEncoder().encode(
+        `${JSON.stringify({ type: "thinking", text: "STALE ANALYSIS" })}\n${JSON.stringify({ type: "progress", chars: 999 })}\n`,
+      ));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(document.body.textContent).not.toContain("STALE ANALYSIS");
+    expect(document.body.textContent).not.toContain("999 chars");
+
+    await act(async () => {
+      currentController.error(new DOMException("cancelled", "AbortError"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
   });
 
   it("makes erase-all reachable when a profile exists without history", async () => {

--- a/lib/pii.test.ts
+++ b/lib/pii.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { protectPii, restorePii } from "./pii";
 
 describe("client-side PII protection", () => {
+  afterEach(() => vi.restoreAllMocks());
   it("replaces common contact data before transmission and restores it afterward", () => {
     const source = "Jane Doe · jane@example.com · (512) 555-0199 · https://linkedin.com/in/jane";
     const protectedValue = protectPii(source);
@@ -62,6 +63,52 @@ describe("client-side PII protection", () => {
 
   it("does not guess personal names when the caller supplies none", () => {
     const source = "Jane Doe led delivery.";
+    expect(protectPii(source)).toEqual({ text: source, matches: [] });
+  });
+
+  it("masks canonically equivalent Unicode forms and restores the original text", () => {
+    const source = "JOSE\u0301 NU\u0301N\u0303EZ led delivery.";
+    const protectedValue = protectPii(source, { candidateNames: ["José Núñez"] });
+    expect(protectedValue.matches.map((match) => match.kind)).toEqual(["candidate name"]);
+    expect(protectedValue.text).not.toContain("JOSE\u0301");
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
+  });
+
+  it.each(["555\u00a0123\u00a04567", "123\u00a045\u00a06789"])(
+    "protects non-breaking-space-delimited personal data %s",
+    (value) => {
+      const protectedValue = protectPii(value);
+      expect(protectedValue.matches).toHaveLength(1);
+      expect(protectedValue.text).not.toContain(value);
+      expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(value);
+    },
+  );
+
+  it("uses collision-resistant tokens and never restores model-added repetitions", () => {
+    const source = "Jane Doe [[RF_CANDIDATE_NAME_1]]";
+    const protectedValue = protectPii(source, { candidateNames: ["Jane Doe"] });
+    expect(protectedValue.text).toContain("[[RF_CANDIDATE_NAME_1]]");
+    expect(protectedValue.matches[0].token).not.toBe("[[RF_CANDIDATE_NAME_1]]");
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
+
+    const repeatedByModel = `${protectedValue.text} ${protectedValue.matches[0].token}`;
+    expect(restorePii(repeatedByModel, protectedValue.matches)).toBe(`${source} ${protectedValue.matches[0].token}`);
+  });
+
+  it("regenerates a random prefix that already occurs in the source", () => {
+    const random = vi.spyOn(globalThis.crypto, "getRandomValues");
+    random.mockImplementationOnce((array) => { (array as Uint8Array).fill(0); return array; });
+    random.mockImplementationOnce((array) => { (array as Uint8Array).fill(1); return array; });
+    const collidingLiteral = `[[RF_${"00".repeat(16)}_CANDIDATE_NAME_1]]`;
+    const source = `${collidingLiteral} Jane Doe`;
+    const protectedValue = protectPii(source, { candidateNames: ["Jane Doe"] });
+    expect(protectedValue.matches[0].token).toContain("01".repeat(16));
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
+    expect(random).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not classify arbitrary project or employer URLs as personal profiles", () => {
+    const source = "https://docs.example.com/project/runbook";
     expect(protectPii(source)).toEqual({ text: source, matches: [] });
   });
 });

--- a/lib/pii.test.ts
+++ b/lib/pii.test.ts
@@ -25,4 +25,43 @@ describe("client-side PII protection", () => {
       expect(protectedValue.text).not.toContain("jane-doe");
     }
   });
+
+  it.each([
+    "5551234567",
+    "(555)1234567",
+    "+44 20 7123 4567",
+  ])("protects defensible compact and international phone form %s", (value) => {
+    const protectedValue = protectPii(`Call ${value} for an interview.`);
+    expect(protectedValue.matches.map((match) => match.kind)).toContain("phone");
+    expect(protectedValue.text).not.toContain(value);
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toContain(value);
+  });
+
+  it.each(["123456789", "123 45 6789"])(
+    "protects compact and spaced government identifier form %s",
+    (value) => {
+      const protectedValue = protectPii(`SSN ${value}`);
+      expect(protectedValue.matches.map((match) => match.kind)).toContain("government identifier");
+      expect(protectedValue.text).not.toContain(value);
+    },
+  );
+
+  it("does not misclassify dates, short numbers, or long account numbers as phones or SSNs", () => {
+    const source = "Dates 2026-07-31 and 07/31/2026; ZIP 78701; account 1234567890123456; candidate ABC5551234567XYZ; employee E123456789Z.";
+    expect(protectPii(source)).toEqual({ text: source, matches: [] });
+  });
+
+  it("masks only explicit caller-supplied candidate names and restores exact casing", () => {
+    const source = "JANE   DOE led delivery. Jane Doe mentored peers. Jane documented it.";
+    const protectedValue = protectPii(source, { candidateNames: ["Jane Doe"] });
+    expect(protectedValue.text).not.toMatch(/jane\s+doe/i);
+    expect(protectedValue.text).toContain("Jane documented it.");
+    expect(protectedValue.matches.filter((match) => match.kind === "candidate name")).toHaveLength(2);
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
+  });
+
+  it("does not guess personal names when the caller supplies none", () => {
+    const source = "Jane Doe led delivery.";
+    expect(protectPii(source)).toEqual({ text: source, matches: [] });
+  });
 });

--- a/lib/pii.test.ts
+++ b/lib/pii.test.ts
@@ -74,6 +74,16 @@ describe("client-side PII protection", () => {
     expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
   });
 
+  it.each([
+    "JOSÉ NU\u0301N\u0303EZ",
+    "JOSE\u0301 NÚÑEZ",
+  ])("masks mixed per-grapheme NFC/NFD candidate name %s", (name) => {
+    const source = `${name} led delivery.`;
+    const protectedValue = protectPii(source, { candidateNames: ["José Núñez"] });
+    expect(protectedValue.matches.map((match) => match.kind)).toEqual(["candidate name"]);
+    expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
+  });
+
   it.each(["555\u00a0123\u00a04567", "123\u00a045\u00a06789"])(
     "protects non-breaking-space-delimited personal data %s",
     (value) => {
@@ -92,7 +102,9 @@ describe("client-side PII protection", () => {
     expect(restorePii(protectedValue.text, protectedValue.matches)).toBe(source);
 
     const repeatedByModel = `${protectedValue.text} ${protectedValue.matches[0].token}`;
-    expect(restorePii(repeatedByModel, protectedValue.matches)).toBe(`${source} ${protectedValue.matches[0].token}`);
+    expect(restorePii(repeatedByModel, protectedValue.matches)).toBe(
+      `${source} [Personal information withheld: unexpected repeated candidate name placeholder]`,
+    );
   });
 
   it("regenerates a random prefix that already occurs in the source", () => {
@@ -110,5 +122,25 @@ describe("client-side PII protection", () => {
   it("does not classify arbitrary project or employer URLs as personal profiles", () => {
     const source = "https://docs.example.com/project/runbook";
     expect(protectPii(source)).toEqual({ text: source, matches: [] });
+  });
+
+  it("masks only root GitHub/GitLab user profiles, not repositories or groups", () => {
+    for (const profile of ["https://github.com/jane-doe", "https://gitlab.com/jane.doe"]) {
+      expect(protectPii(profile).matches.map((match) => match.kind)).toEqual(["web profile"]);
+    }
+    for (const project of ["https://github.com/jane-doe/resume", "https://gitlab.com/team/project"]) {
+      expect(protectPii(project)).toEqual({ text: project, matches: [] });
+    }
+  });
+
+  it("restores document fields in a deterministic priority and surfaces excess placeholders", () => {
+    const protectedValue = protectPii("Jane Doe", { candidateNames: ["Jane Doe"] });
+    const token = protectedValue.matches[0].token;
+    const first = restorePii({ cover_letter_markdown: token, tailored_resume_markdown: token }, protectedValue.matches);
+    const second = restorePii({ tailored_resume_markdown: token, cover_letter_markdown: token }, protectedValue.matches);
+    const withheld = "[Personal information withheld: unexpected repeated candidate name placeholder]";
+    expect(first).toEqual({ tailored_resume_markdown: "Jane Doe", cover_letter_markdown: withheld });
+    expect(second).toEqual(first);
+    expect(JSON.stringify(first)).not.toContain("[[RF_");
   });
 });

--- a/lib/pii.ts
+++ b/lib/pii.ts
@@ -1,23 +1,61 @@
 export type PrivacyMode = "protect" | "review" | "exact";
 
 export interface PiiMatch {
-  kind: "email" | "phone" | "web profile" | "street address" | "government identifier";
+  kind: "candidate name" | "email" | "phone" | "web profile" | "street address" | "government identifier";
   value: string;
   token: string;
 }
 
 const PATTERNS: Array<{ kind: PiiMatch["kind"]; pattern: RegExp }> = [
-  { kind: "government identifier", pattern: /\b\d{3}-\d{2}-\d{4}\b/g },
   { kind: "email", pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi },
-  { kind: "phone", pattern: /(?<!\d)(?:\+?1[ .-]?)?(?:\(\d{3}\)|\d{3})[ .-]\d{3}[ .-]\d{4}(?!\d)/g },
+  // An explicit + prefix is the conservative signal for international forms.
+  // The digit count follows E.164's broad 8..15 digit envelope without
+  // claiming that every national numbering plan is understood here.
+  { kind: "phone", pattern: /(?<![\p{L}\p{N}])\+\d(?:[ .()\-]*\d){7,14}(?!\d)/gu },
+  // US/NANP-shaped values, including compact and parenthesized forms commonly
+  // pasted from resumes. Exact ten-digit delimiting avoids matching inside a
+  // longer account or card number.
+  { kind: "phone", pattern: /(?<![\p{L}\p{N}])(?:\+?1[ .-]?)?(?:\(\d{3}\)|\d{3})[ .-]?\d{3}[ .-]?\d{4}(?![\p{L}\p{N}])/gu },
+  // Delimit the complete value so dates and longer account/card numbers do not
+  // produce a partial match. Compact identifiers can still collide with an
+  // unrelated nine-digit identifier; review mode exists for that ambiguity.
+  { kind: "government identifier", pattern: /(?<![\p{L}\p{N}])(?:\d{3}-\d{2}-\d{4}|\d{3} \d{2} \d{4}|\d{9})(?![\p{L}\p{N}])/gu },
   { kind: "web profile", pattern: /(?:https?:\/\/)?(?:www\.)?(?:linkedin\.com\/in|github\.com|gitlab\.com|[A-Z0-9.-]+\.[A-Z]{2,})\/[^\s)\]}]+/gi },
   { kind: "street address", pattern: /\b\d{1,6}\s+[A-Z0-9.' -]{2,50}\s(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Way)\b[.,]?/gi },
 ];
 
-export function protectPii(text: string): { text: string; matches: PiiMatch[] } {
+export interface ProtectPiiOptions {
+  /**
+   * Names the user explicitly identifies as their own. Names are not guessed:
+   * arbitrary proper-name detection creates unsafe false positives and misses
+   * too many cultures and formats to support an automatic claim.
+   */
+  candidateNames?: readonly string[];
+}
+
+function escapePattern(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function candidateNamePatterns(names: readonly string[]): RegExp[] {
+  const unique = new Set<string>();
+  const patterns: RegExp[] = [];
+  for (const rawName of names) {
+    const name = rawName.trim().replace(/\s+/g, " ");
+    const identity = name.toLocaleLowerCase();
+    if (name.length < 2 || name.length > 120 || !/\p{L}/u.test(name) || unique.has(identity)) continue;
+    unique.add(identity);
+    const body = name.split(" ").map(escapePattern).join("\\s+");
+    patterns.push(new RegExp(`(?<![\\p{L}\\p{N}])${body}(?![\\p{L}\\p{N}])`, "giu"));
+  }
+  return patterns;
+}
+
+export function protectPii(text: string, options: ProtectPiiOptions = {}): { text: string; matches: PiiMatch[] } {
   let protectedText = text;
   const matches: PiiMatch[] = [];
-  for (const { kind, pattern } of PATTERNS) {
+
+  const replaceMatches = (kind: PiiMatch["kind"], pattern: RegExp) => {
     protectedText = protectedText.replace(pattern, (value) => {
       const existing = matches.find((match) => match.value === value && match.kind === kind);
       if (existing) return existing.token;
@@ -25,6 +63,13 @@ export function protectPii(text: string): { text: string; matches: PiiMatch[] } 
       matches.push({ kind, value, token });
       return token;
     });
+  };
+
+  for (const pattern of candidateNamePatterns(options.candidateNames ?? [])) {
+    replaceMatches("candidate name", pattern);
+  }
+  for (const { kind, pattern } of PATTERNS) {
+    replaceMatches(kind, pattern);
   }
   return { text: protectedText, matches };
 }

--- a/lib/pii.ts
+++ b/lib/pii.ts
@@ -4,6 +4,7 @@ export interface PiiMatch {
   kind: "candidate name" | "email" | "phone" | "web profile" | "street address" | "government identifier";
   value: string;
   token: string;
+  occurrences: number;
 }
 
 const PATTERNS: Array<{ kind: PiiMatch["kind"]; pattern: RegExp }> = [
@@ -11,16 +12,18 @@ const PATTERNS: Array<{ kind: PiiMatch["kind"]; pattern: RegExp }> = [
   // An explicit + prefix is the conservative signal for international forms.
   // The digit count follows E.164's broad 8..15 digit envelope without
   // claiming that every national numbering plan is understood here.
-  { kind: "phone", pattern: /(?<![\p{L}\p{N}])\+\d(?:[ .()\-]*\d){7,14}(?!\d)/gu },
+  { kind: "phone", pattern: /(?<![\p{L}\p{N}\p{M}])\+\d(?:[.()\-\p{Z}\s]*\d){7,14}(?!\d)/gu },
   // US/NANP-shaped values, including compact and parenthesized forms commonly
   // pasted from resumes. Exact ten-digit delimiting avoids matching inside a
   // longer account or card number.
-  { kind: "phone", pattern: /(?<![\p{L}\p{N}])(?:\+?1[ .-]?)?(?:\(\d{3}\)|\d{3})[ .-]?\d{3}[ .-]?\d{4}(?![\p{L}\p{N}])/gu },
+  { kind: "phone", pattern: /(?<![\p{L}\p{N}\p{M}])(?:\+?1[.\-\p{Z}\s]?)?(?:\(\d{3}\)|\d{3})[.\-\p{Z}\s]?\d{3}[.\-\p{Z}\s]?\d{4}(?![\p{L}\p{N}\p{M}])/gu },
   // Delimit the complete value so dates and longer account/card numbers do not
   // produce a partial match. Compact identifiers can still collide with an
   // unrelated nine-digit identifier; review mode exists for that ambiguity.
-  { kind: "government identifier", pattern: /(?<![\p{L}\p{N}])(?:\d{3}-\d{2}-\d{4}|\d{3} \d{2} \d{4}|\d{9})(?![\p{L}\p{N}])/gu },
-  { kind: "web profile", pattern: /(?:https?:\/\/)?(?:www\.)?(?:linkedin\.com\/in|github\.com|gitlab\.com|[A-Z0-9.-]+\.[A-Z]{2,})\/[^\s)\]}]+/gi },
+  { kind: "government identifier", pattern: /(?<![\p{L}\p{N}\p{M}])(?:\d{3}-\d{2}-\d{4}|\d{3}[\p{Z}\s]\d{2}[\p{Z}\s]\d{4}|\d{9})(?![\p{L}\p{N}\p{M}])/gu },
+  // Infer only well-known profile hosts. Generic URLs may identify an
+  // employer, project, portfolio, or documentation page.
+  { kind: "web profile", pattern: /(?:https?:\/\/)?(?:www\.)?(?:linkedin\.com\/in|github\.com|gitlab\.com)\/[^\s)\]}]+/gi },
   { kind: "street address", pattern: /\b\d{1,6}\s+[A-Z0-9.' -]{2,50}\s(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Way)\b[.,]?/gi },
 ];
 
@@ -41,12 +44,14 @@ function candidateNamePatterns(names: readonly string[]): RegExp[] {
   const unique = new Set<string>();
   const patterns: RegExp[] = [];
   for (const rawName of names) {
-    const name = rawName.trim().replace(/\s+/g, " ");
-    const identity = name.toLocaleLowerCase();
+    const name = rawName.trim().replace(/[\p{Z}\s]+/gu, " ").normalize("NFC");
+    const identity = name.toLocaleLowerCase().normalize("NFC");
     if (name.length < 2 || name.length > 120 || !/\p{L}/u.test(name) || unique.has(identity)) continue;
     unique.add(identity);
-    const body = name.split(" ").map(escapePattern).join("\\s+");
-    patterns.push(new RegExp(`(?<![\\p{L}\\p{N}])${body}(?![\\p{L}\\p{N}])`, "giu"));
+    for (const form of new Set([name.normalize("NFC"), name.normalize("NFD")])) {
+      const body = form.split(" ").map(escapePattern).join("[\\p{Z}\\s]+");
+      patterns.push(new RegExp(`(?<![\\p{L}\\p{N}\\p{M}])${body}(?![\\p{L}\\p{N}\\p{M}])`, "giu"));
+    }
   }
   return patterns;
 }
@@ -54,13 +59,14 @@ function candidateNamePatterns(names: readonly string[]): RegExp[] {
 export function protectPii(text: string, options: ProtectPiiOptions = {}): { text: string; matches: PiiMatch[] } {
   let protectedText = text;
   const matches: PiiMatch[] = [];
+  const tokenPrefix = randomTokenPrefix(text);
 
   const replaceMatches = (kind: PiiMatch["kind"], pattern: RegExp) => {
     protectedText = protectedText.replace(pattern, (value) => {
       const existing = matches.find((match) => match.value === value && match.kind === kind);
-      if (existing) return existing.token;
-      const token = `[[RF_${kind.toUpperCase().replace(/\s+/g, "_")}_${matches.length + 1}]]`;
-      matches.push({ kind, value, token });
+      if (existing) { existing.occurrences += 1; return existing.token; }
+      const token = `[[RF_${tokenPrefix}_${kind.toUpperCase().replace(/\s+/g, "_")}_${matches.length + 1}]]`;
+      matches.push({ kind, value, token, occurrences: 1 });
       return token;
     });
   };
@@ -74,17 +80,36 @@ export function protectPii(text: string, options: ProtectPiiOptions = {}): { tex
   return { text: protectedText, matches };
 }
 
+function randomTokenPrefix(source: string): string {
+  const cryptoProvider = globalThis.crypto;
+  if (!cryptoProvider?.getRandomValues) throw new Error("Secure random values are required for PII protection.");
+  for (;;) {
+    const bytes = cryptoProvider.getRandomValues(new Uint8Array(16));
+    const prefix = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+    if (!source.includes(`[[RF_${prefix}_`)) return prefix;
+  }
+}
+
 export function restorePii<T>(value: T, matches: PiiMatch[]): T {
-  if (typeof value === "string") {
-    let restored = value as string;
-    for (const match of matches) restored = restored.split(match.token).join(match.value);
-    return restored as T;
-  }
-  if (Array.isArray(value)) return value.map((item) => restorePii(item, matches)) as T;
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, restorePii(item, matches)]),
-    ) as T;
-  }
-  return value;
+  const remaining = new Map(matches.map((match) => [match.token, match.occurrences]));
+  const restore = (item: unknown): unknown => {
+    if (typeof item === "string") {
+      let restored = item;
+      for (const match of matches) {
+        restored = restored.replaceAll(match.token, () => {
+          const available = remaining.get(match.token) ?? 0;
+          if (available <= 0) return match.token;
+          remaining.set(match.token, available - 1);
+          return match.value;
+        });
+      }
+      return restored;
+    }
+    if (Array.isArray(item)) return item.map(restore);
+    if (item && typeof item === "object") {
+      return Object.fromEntries(Object.entries(item).map(([key, nested]) => [key, restore(nested)]));
+    }
+    return item;
+  };
+  return restore(value) as T;
 }

--- a/lib/pii.ts
+++ b/lib/pii.ts
@@ -23,7 +23,7 @@ const PATTERNS: Array<{ kind: PiiMatch["kind"]; pattern: RegExp }> = [
   { kind: "government identifier", pattern: /(?<![\p{L}\p{N}\p{M}])(?:\d{3}-\d{2}-\d{4}|\d{3}[\p{Z}\s]\d{2}[\p{Z}\s]\d{4}|\d{9})(?![\p{L}\p{N}\p{M}])/gu },
   // Infer only well-known profile hosts. Generic URLs may identify an
   // employer, project, portfolio, or documentation page.
-  { kind: "web profile", pattern: /(?:https?:\/\/)?(?:www\.)?(?:linkedin\.com\/in|github\.com|gitlab\.com)\/[^\s)\]}]+/gi },
+  { kind: "web profile", pattern: /(?:https?:\/\/)?(?:www\.)?(?:linkedin\.com\/in\/[A-Z0-9_.%-]+|github\.com\/[A-Z0-9-]+|gitlab\.com\/[A-Z0-9_.-]+)(?![A-Z0-9_.\/-])\/?(?:[?#][^\s)\]}]*)?/gi },
   { kind: "street address", pattern: /\b\d{1,6}\s+[A-Z0-9.' -]{2,50}\s(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Way)\b[.,]?/gi },
 ];
 
@@ -48,10 +48,14 @@ function candidateNamePatterns(names: readonly string[]): RegExp[] {
     const identity = name.toLocaleLowerCase().normalize("NFC");
     if (name.length < 2 || name.length > 120 || !/\p{L}/u.test(name) || unique.has(identity)) continue;
     unique.add(identity);
-    for (const form of new Set([name.normalize("NFC"), name.normalize("NFD")])) {
-      const body = form.split(" ").map(escapePattern).join("[\\p{Z}\\s]+");
-      patterns.push(new RegExp(`(?<![\\p{L}\\p{N}\\p{M}])${body}(?![\\p{L}\\p{N}\\p{M}])`, "giu"));
-    }
+    const body = name.split(" ").map((word) => {
+      const graphemes = word.normalize("NFD").match(/\P{M}\p{M}*/gu) ?? [];
+      return graphemes.map((grapheme) => {
+        const variants = [...new Set([grapheme.normalize("NFC"), grapheme.normalize("NFD")])].map(escapePattern);
+        return variants.length === 1 ? variants[0] : `(?:${variants.join("|")})`;
+      }).join("");
+    }).join("[\\p{Z}\\s]+");
+    patterns.push(new RegExp(`(?<![\\p{L}\\p{N}\\p{M}])${body}(?![\\p{L}\\p{N}\\p{M}])`, "giu"));
   }
   return patterns;
 }
@@ -98,7 +102,7 @@ export function restorePii<T>(value: T, matches: PiiMatch[]): T {
       for (const match of matches) {
         restored = restored.replaceAll(match.token, () => {
           const available = remaining.get(match.token) ?? 0;
-          if (available <= 0) return match.token;
+          if (available <= 0) return `[Personal information withheld: unexpected repeated ${match.kind} placeholder]`;
           remaining.set(match.token, available - 1);
           return match.value;
         });
@@ -107,7 +111,14 @@ export function restorePii<T>(value: T, matches: PiiMatch[]): T {
     }
     if (Array.isArray(item)) return item.map(restore);
     if (item && typeof item === "object") {
-      return Object.fromEntries(Object.entries(item).map(([key, nested]) => [key, restore(nested)]));
+      const entries = Object.entries(item);
+      const priority = new Map(["tailored_resume_markdown", "cover_letter_markdown"].map((key, index) => [key, index]));
+      entries.sort(([left], [right]) => {
+        const leftPriority = priority.get(left) ?? Number.MAX_SAFE_INTEGER;
+        const rightPriority = priority.get(right) ?? Number.MAX_SAFE_INTEGER;
+        return leftPriority - rightPriority || (left < right ? -1 : left > right ? 1 : 0);
+      });
+      return Object.fromEntries(entries.map(([key, nested]) => [key, restore(nested)]));
     }
     return item;
   };

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -21,11 +21,16 @@ import { createJobSnapshot } from "./job-inbox";
 import { createApplicationPacket, createApplicationRecord } from "./applications";
 import type { TailorResult } from "./schema";
 
+const { deleteCareerLedgerMock } = vi.hoisted(() => ({ deleteCareerLedgerMock: vi.fn(async () => undefined) }));
+vi.mock("./career-vault", () => ({ deleteCareerLedger: deleteCareerLedgerMock }));
+
 class MemoryStorage {
   #values = new Map<string, string>();
   getItem(key: string) { return this.#values.get(key) ?? null; }
   setItem(key: string, value: string) { this.#values.set(key, value); }
   removeItem(key: string) { this.#values.delete(key); }
+  get length() { return this.#values.size; }
+  key(index: number) { return Array.from(this.#values.keys())[index] ?? null; }
 }
 
 const session: Session = {
@@ -38,7 +43,7 @@ const session: Session = {
   result: null,
 };
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => { vi.unstubAllGlobals(); deleteCareerLedgerMock.mockReset(); deleteCareerLedgerMock.mockResolvedValue(undefined); });
 
 describe("local save points", () => {
   beforeEach(() => {
@@ -63,6 +68,14 @@ describe("local save points", () => {
     expect(loadProfile()).toMatchObject({ candidateName: "", resume: "legacy" });
   });
 
+  it("migrates older save points without inventing a candidate name", () => {
+    localStorage.setItem("art:save-points", JSON.stringify([{
+      id: "legacy", createdAt: 1, label: "Legacy",
+      profile: { resume: "legacy resume", extraInfo: "" }, session,
+    }]));
+    expect(loadSavePoints()[0].profile).toEqual({ candidateName: "", resume: "legacy resume", extraInfo: "" });
+  });
+
   it("deduplicates identical consecutive states", () => {
     addSavePoint({ resume: "same", extraInfo: "" }, session);
     addSavePoint({ resume: "same", extraInfo: "" }, session);
@@ -80,9 +93,21 @@ describe("local save points", () => {
   });
 
   it("erases checkpoints with the rest of the local user data", async () => {
-    addSavePoint({ resume: "private", extraInfo: "" }, session);
+    saveProfile({ candidateName: "Jane Doe", resume: "private", extraInfo: "" });
+    addSavePoint({ candidateName: "Jane Doe", resume: "private", extraInfo: "" }, session);
     await clearAllData();
     expect(loadSavePoints()).toEqual([]);
+    expect(loadProfile()).toBeNull();
+  });
+
+  it("clears browser records and announces cleanup even when vault deletion fails", async () => {
+    saveProfile({ candidateName: "Jane Doe", resume: "private", extraInfo: "" });
+    const dispatchEvent = vi.fn();
+    Object.assign(window, { dispatchEvent });
+    deleteCareerLedgerMock.mockRejectedValueOnce(new Error("vault unavailable"));
+    await expect(clearAllData()).rejects.toThrow(/encrypted career ledger/);
+    expect(loadProfile()).toBeNull();
+    expect(dispatchEvent).toHaveBeenCalledOnce();
   });
   it("quarantines malformed persisted history instead of bricking every reload", () => {
     localStorage.setItem("art:history", JSON.stringify([{ result: { broken: true } }]));

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -55,6 +55,14 @@ describe("local save points", () => {
     expect(deleteSavePoint(points[0].id)).toEqual([]);
   });
 
+  it("persists an explicit candidate name and migrates older profiles without guessing one", () => {
+    saveProfile({ candidateName: "Jane Doe", resume: "resume", extraInfo: "" });
+    expect(loadProfile()?.candidateName).toBe("Jane Doe");
+
+    localStorage.setItem("art:profile", JSON.stringify({ resume: "legacy", extraInfo: "", updatedAt: 1 }));
+    expect(loadProfile()).toMatchObject({ candidateName: "", resume: "legacy" });
+  });
+
   it("deduplicates identical consecutive states", () => {
     addSavePoint({ resume: "same", extraInfo: "" }, session);
     addSavePoint({ resume: "same", extraInfo: "" }, session);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -246,7 +246,8 @@ export async function clearAllData(): Promise<void> {
     }
   } catch (error) { failures.push(new LocalPersistenceError("erasing local data", { cause: error })); }
   try { clearCareerPathRecords(); } catch (error) { failures.push(error); }
-  try { await deleteCareerLedger(); } catch (error) { failures.push(error); }
+  try { await deleteCareerLedger(); }
+  catch (error) { failures.push(new LocalPersistenceError("erasing the encrypted career ledger", { cause: error })); }
   try { window.dispatchEvent?.(new Event("resume-foundry:data-cleared")); } catch (error) { failures.push(error); }
   if (failures.length) throw failures[0];
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -247,7 +247,10 @@ export async function clearAllData(): Promise<void> {
   } catch (error) { failures.push(new LocalPersistenceError("erasing local data", { cause: error })); }
   try { clearCareerPathRecords(); } catch (error) { failures.push(error); }
   try { await deleteCareerLedger(); }
-  catch (error) { failures.push(new LocalPersistenceError("erasing the encrypted career ledger", { cause: error })); }
+  catch (error) {
+    const detail = error instanceof Error && error.message ? `: ${error.message}` : "";
+    failures.push(new LocalPersistenceError(`erasing the encrypted career ledger${detail}`, { cause: error }));
+  }
   try { window.dispatchEvent?.(new Event("resume-foundry:data-cleared")); } catch (error) { failures.push(error); }
   if (failures.length) throw failures[0];
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -12,6 +12,8 @@ import { clearCareerPathRecords } from "./labor-market-storage";
  */
 
 export interface Profile {
+  /** User-supplied identity used for exact, local PII masking; never inferred. */
+  candidateName?: string;
   resume: string;
   /** Anything that doesn't fit the resume: side projects, metrics, preferences. */
   extraInfo: string;
@@ -56,12 +58,12 @@ function writeStored(key: string, value: unknown, operation: string): void {
     throw new LocalPersistenceError(operation, { cause: error });
   }
 }
-const ProfileSchema = z.strictObject({ resume: z.string(), extraInfo: z.string(), updatedAt: z.number().finite() });
+const ProfileSchema = z.strictObject({ candidateName: z.string().max(120).optional().default(""), resume: z.string(), extraInfo: z.string(), updatedAt: z.number().finite() });
 const HistoryEntrySchema = z.strictObject({ id: z.string().min(1), createdAt: z.number().finite(), jobTitle: z.string(), company: z.string(), result: TailorResultSchema });
 const SessionSchema = z.strictObject({ jobText: z.string(), jobUrl: z.string(), jobTitle: z.string(), company: z.string(), emphasis: z.enum(["balanced", "technical", "leadership"]), privacyMode: z.enum(["protect", "review", "exact"]), result: TailorResultSchema.nullable() }).partial();
 const SavePointSchema = z.strictObject({
   id: z.string().min(1), createdAt: z.number().finite(), label: z.string(),
-  profile: z.strictObject({ resume: z.string(), extraInfo: z.string() }),
+  profile: z.strictObject({ candidateName: z.string().max(120).optional().default(""), resume: z.string(), extraInfo: z.string() }),
   session: SessionSchema.required(),
 });
 const ApplicationPacketSchema = z.strictObject({
@@ -141,7 +143,7 @@ export interface SavePoint {
   id: string;
   createdAt: number;
   label: string;
-  profile: Pick<Profile, "resume" | "extraInfo">;
+  profile: Pick<Profile, "resume" | "extraInfo"> & Pick<Profile, "candidateName">;
   session: Session;
 }
 
@@ -180,18 +182,19 @@ export function loadSavePoints(): SavePoint[] {
 }
 
 export function addSavePoint(
-  profile: Pick<Profile, "resume" | "extraInfo">,
+  profile: Pick<Profile, "resume" | "extraInfo"> & Pick<Profile, "candidateName">,
   session: Session,
   label = "Automatic checkpoint",
 ): SavePoint[] {
   const current = loadSavePoints();
-  const comparable = JSON.stringify({ profile, session });
+  const normalizedProfile = { candidateName: profile.candidateName ?? "", resume: profile.resume, extraInfo: profile.extraInfo };
+  const comparable = JSON.stringify({ profile: normalizedProfile, session });
   const latest = current[0];
   if (latest && JSON.stringify({ profile: latest.profile, session: latest.session }) === comparable) {
     return current;
   }
   const next = [
-    { id: crypto.randomUUID(), createdAt: Date.now(), label, profile, session },
+    { id: crypto.randomUUID(), createdAt: Date.now(), label, profile: normalizedProfile, session },
     ...current,
   ].slice(0, SAVE_POINTS_LIMIT);
   if (typeof window !== "undefined") writeStored(SAVE_POINTS_KEY, next, "saving a recovery checkpoint");


### PR DESCRIPTION
## What changed
- persist an explicit candidate name and protect it across resume, cover-letter, save-point, migration, and erase flows
- detect compact, parenthesized, international, spaced, and Unicode-normalized identifiers
- restore protected values deterministically without allowing model-invented token duplication
- distinguish profile URLs from repository URLs and prove Exact mode remains user-selectable

## Why
Protect mode previously missed common identifiers and Unicode forms, and token restoration could depend on object order or reproduce excess model tokens.

## Validation
- 209/209 tests
- lint, typecheck, build pass
- npm audit: 0 vulnerabilities
- exact-mode and protect/review browser flows covered

Draft pending independent adversarial re-review.