### PR TITLE
Add How It Works and About pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteNav } from "@/components/SiteNav";
+
+export const metadata: Metadata = {
+  title: "About Resume Foundry",
+  description: "Resume Foundry's purpose, principles, privacy boundary, and current product limits.",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-24 pt-8 md:px-8">
+      <SiteNav current="/about" />
+      <main>
+        <p className="font-mono text-[11px] uppercase tracking-[0.25em] text-brass-400">Built around evidence, agency, and durable career memory</p>
+        <h1 className="mt-3 font-display text-4xl font-semibold text-paper md:text-5xl">About Resume Foundry</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-ink-300">
+          Resume Foundry is a candidate-controlled workspace for preserving career evidence, understanding opportunities, tailoring honest application materials, and remembering what was sent where.
+        </p>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-3">
+          <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-5">
+            <h2 className="font-display text-xl font-semibold text-paper">Evidence before polish</h2>
+            <p className="mt-2 text-sm leading-6 text-ink-300">A stronger sentence is useful only when the underlying experience supports it. Unsupported requirements remain visible instead of being fabricated.</p>
+          </section>
+          <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-5">
+            <h2 className="font-display text-xl font-semibold text-paper">The candidate stays in control</h2>
+            <p className="mt-2 text-sm leading-6 text-ink-300">Privacy modes, manual editing, approvals, exports, deletion, and recovery are user choices—not hidden automation.</p>
+          </section>
+          <section className="rounded-xl border border-ink-700 bg-ink-900/70 p-5">
+            <h2 className="font-display text-xl font-semibold text-paper">A career is bigger than a resume</h2>
+            <p className="mt-2 text-sm leading-6 text-ink-300">The Career Ledger preserves projects, learning, work, and verified evidence so today’s overlooked experience can become tomorrow’s relevant proof.</p>
+          </section>
+        </div>
+
+        <section className="mt-10 space-y-3 border-t border-ink-700 pt-8" aria-labelledby="privacy-heading">
+          <h2 id="privacy-heading" className="font-display text-2xl font-semibold text-paper">Privacy and operating boundary</h2>
+          <p className="max-w-3xl text-sm leading-6 text-ink-300">
+            The workshop profile, active session, save points, and run history are browser-local. Tailoring sends the selected resume and job text to the deployment’s configured Anthropic API. Optional integrations have their own explicit configuration and consent boundaries. Browser storage is convenient, but long-term records should also be exported and backed up by the user.
+          </p>
+        </section>
+
+        <section className="mt-8 space-y-3 border-t border-ink-700 pt-8" aria-labelledby="status-heading">
+          <h2 id="status-heading" className="font-display text-2xl font-semibold text-paper">Current status</h2>
+          <p className="max-w-3xl text-sm leading-6 text-ink-300">
+            The repository is a tested reference implementation suitable for local and controlled demonstrations. Real employer submission, public multi-user hosting, external credential interoperability, and regulated production use require separate deployment controls, partner authorization, operational readiness, and independent review.
+          </p>
+        </section>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link href="/" className="rounded-lg bg-brass-400 px-5 py-3 text-sm font-semibold text-ink-950">Open the workshop</Link>
+          <Link href="/how-it-works" className="rounded-lg border border-ink-600 px-5 py-3 text-sm font-semibold text-paper hover:bg-ink-800">See how it works</Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteNav } from "@/components/SiteNav";
+
+export const metadata: Metadata = {
+  title: "How Resume Foundry works",
+  description: "A practical guide to building a profile, importing a job, protecting personal information, tailoring documents, and tracking applications.",
+};
+
+const steps = [
+  ["Build your evidence base", "Paste or upload your master resume and add useful background. Resume Foundry saves this working profile in your browser and never invents missing experience."],
+  ["Bring in a real job", "Paste a posting, import supported job data, or fetch an allowed public job URL. Review the title, employer, requirements, and source before using it."],
+  ["Choose your privacy level", "Protect mode masks detected personal details before generation and restores them locally afterward. Review mode shows detections first. Exact mode sends the text you entered."],
+  ["Forge and review", "The configured Anthropic model drafts an evidence-linked resume and cover letter. Inspect the requirement map, unsupported gaps, wording changes, and ATS checks before accepting anything."],
+  ["Export and track", "Download or copy the reviewed documents, preserve the exact application packet, and record submission, interview, offer, rejection, and follow-up events."],
+  ["Keep the long view", "Save points protect active work. The encrypted Career Ledger can retain projects, learning, work, and attestations that may become relevant years later."],
+] as const;
+
+export default function HowItWorksPage() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-24 pt-8 md:px-8">
+      <SiteNav current="/how-it-works" />
+      <main>
+        <p className="font-mono text-[11px] uppercase tracking-[0.25em] text-brass-400">From source evidence to reviewed application</p>
+        <h1 className="mt-3 font-display text-4xl font-semibold text-paper md:text-5xl">How it works</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-ink-300">
+          Resume Foundry helps you tailor and organize your work without turning AI output into an unchecked claim. You remain the final reviewer and nothing is submitted to an employer without an explicit approval flow.
+        </p>
+
+        <ol className="mt-10 grid gap-4 md:grid-cols-2">
+          {steps.map(([title, body], index) => (
+            <li key={title} className="rounded-xl border border-ink-700 bg-ink-900/70 p-5">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-brass-400">Step {String(index + 1).padStart(2, "0")}</p>
+              <h2 className="mt-2 font-display text-xl font-semibold text-paper">{title}</h2>
+              <p className="mt-2 text-sm leading-6 text-ink-300">{body}</p>
+            </li>
+          ))}
+        </ol>
+
+        <section className="mt-10 rounded-xl border border-brass-400/30 bg-brass-400/10 p-6" aria-labelledby="limits-heading">
+          <h2 id="limits-heading" className="font-display text-2xl font-semibold text-paper">What the tool does not decide for you</h2>
+          <p className="mt-3 text-sm leading-6 text-ink-300">
+            Match scores are decision support, not hiring predictions. Labor-market projections are not guarantees. Generated documents still require human review. Employer submissions and connected services work only when their separate credentials, approvals, and safeguards are configured.
+          </p>
+        </section>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link href="/" className="rounded-lg bg-brass-400 px-5 py-3 text-sm font-semibold text-ink-950">Open the workshop</Link>
+          <Link href="/about" className="rounded-lg border border-ink-600 px-5 py-3 text-sm font-semibold text-paper hover:bg-ink-800">Read about the project</Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,7 @@ import { CareerLedger } from "@/components/CareerLedger";
 import { CareerPathPlanner } from "@/components/CareerPathPlanner";
 import { Connections } from "@/components/Connections";
 import { SensitiveAttestationBoundary } from "@/components/SensitiveAttestationBoundary";
+import { SiteNav } from "@/components/SiteNav";
 
 type Phase = "idle" | "working" | "done" | "error";
 
@@ -401,6 +402,7 @@ export default function Home() {
 
   return (
     <div ref={pageRef} className="mx-auto max-w-6xl px-4 pb-24 pt-10 md:px-8">
+      <SiteNav current="/" />
       {/* Masthead */}
       <header className="rise mb-10 border-b border-ink-700 pb-8">
         <div className="flex flex-wrap items-end justify-between gap-4">

--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "Workshop" },
+  { href: "/how-it-works", label: "How it works" },
+  { href: "/about", label: "About" },
+] as const;
+
+export function SiteNav({ current }: { current: (typeof links)[number]["href"] }) {
+  return (
+    <nav aria-label="Primary navigation" className="mb-8 flex flex-wrap items-center gap-2 border-b border-ink-700 pb-4">
+      <Link href="/" className="mr-auto font-display text-xl font-semibold text-paper">
+        Resume <em className="text-brass-300">Foundry</em>
+      </Link>
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          aria-current={current === link.href ? "page" : undefined}
+          className={`rounded-lg px-3 py-2 text-xs font-semibold transition ${
+            current === link.href
+              ? "bg-brass-400/15 text-brass-300"
+              : "text-ink-300 hover:bg-ink-800 hover:text-paper"
+          }`}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## What changed
- adds persistent Workshop, How it works, and About navigation
- adds a six-step usage guide with explicit human-review and integration boundaries
- adds an About page covering purpose, principles, privacy, storage, and current maturity
- provides page-specific metadata and accessible current-page navigation

## Why
New users need a clear route from profile creation through privacy review, generation, export, and tracking, plus an honest explanation of what Resume Foundry is and is not.

## Validation
- npm test: 340/340
- npm run lint
- npm run typecheck
- npm run build