### PR TITLE
Document fail-closed deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ RESUME_FOUNDRY_DAILY_APPLICATION_LIMIT=10
 # Required for agent operations; use an absolute path on durable storage.
 RESUME_FOUNDRY_AGENT_STORE=C:\path\to\private\resume-foundry-agent-store.json
 
+# Windows production startup secures every configured sensitive path before
+# serving. Use "apply" for a dedicated service account that may provision ACLs,
+# or "verify" when deployment tooling provisions them first.
+RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply
+
 # Required in production for cross-process, single-host public endpoint limits.
 # Put this on a private durable local volume shared by every Node worker.
 RESUME_FOUNDRY_RATE_LIMIT_DIR=C:\path\to\private\resume-foundry-rate-limits
@@ -44,6 +49,8 @@ LEVER_POSTINGS_API_KEY=
 # Append-only JSONL record of consumed approvals. Single-use nonce markers go to
 # a sibling "<path>.nonces" directory on the same durable volume.
 RESUME_FOUNDRY_SUBMISSION_LEDGER=C:\path\to\private\resume-foundry-submission-ledger.jsonl
+# Durable cross-process single-use markers for approval and attestation nonces.
+RESUME_FOUNDRY_NONCE_STORE=C:\path\to\private\resume-foundry-nonces
 # Durable exact-packet provider-attempt records. Pending records never expire
 # automatically; follow docs/OFFICIAL_SUBMISSIONS.md after a process crash.
 RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR=C:\path\to\private\resume-foundry-submission-attempts

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cp .env.example .env.local   # add your ANTHROPIC_API_KEY
 npm run dev                  # http://localhost:3000
 ```
 
-Get an API key at [platform.claude.com](https://platform.claude.com/). The only required variable is `ANTHROPIC_API_KEY`; `RESUME_FOUNDRY_ANTHROPIC_MODEL` optionally overrides the default `claude-opus-5` without inheriting unrelated Claude CLI model aliases. `ANTHROPIC_MODEL` remains a lower-priority compatibility fallback.
+Get an API key at [platform.claude.com](https://platform.claude.com/). `ANTHROPIC_API_KEY` enables tailoring, and `RESUME_FOUNDRY_ANTHROPIC_MODEL` optionally overrides the default `claude-opus-5` without inheriting unrelated Claude CLI model aliases. A production server also requires a private `RESUME_FOUNDRY_RATE_LIMIT_DIR`. Agent, MCP, Google, and employer-submission features have additional fail-closed requirements; follow the [deployment runbook](docs/DEPLOYMENT.md) instead of treating `.env.example` as a copy-and-run production configuration.
 
 The USAJOBS connector additionally reads `USAJOBS_API_KEY` and `USAJOBS_USER_AGENT`; Greenhouse and Lever public-board imports require no stored credentials. Career-path O*NET v2 lookup reads server-only `ONET_API_KEY`; optional `BLS_API_KEY` increases the public BLS API quota. The BLS time-series endpoint is not treated as an occupational-projections feed. Pasted projection and training catalogs are labeled user-supplied/unverified rather than provider-verified.
 
@@ -66,6 +66,7 @@ The USAJOBS connector additionally reads `USAJOBS_API_KEY` and `USAJOBS_USER_AGE
 CI runs lint, typecheck, tests, build, and a high-severity dependency audit on every push and PR.
 
 The labor-market route contracts and deployment boundaries are documented in [`docs/LABOR_MARKET_API.md`](docs/LABOR_MARKET_API.md).
+Production environment profiles, Windows ACL provisioning, startup order, and failure diagnosis are documented in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
 
 ## Architecture
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,96 @@
+# Deployment runbook
+
+Resume Foundry intentionally fails closed when a feature needs durable security state and its deployment has not supplied it. A local development server and a production server do not have the same minimum environment. Start with the smallest profile below and add a capability only when its entire row is configured.
+
+Never commit `.env.local` or `.env.production.local`. Both are ignored by Git. In a hosted deployment, inject secrets from the platform secret manager and mount durable private paths separately from the application checkout.
+
+## Environment profiles
+
+| Capability | Required configuration | What happens when it is absent |
+|---|---|---|
+| Local UI without generation | none (`npm run dev`) | The workshop loads; generation cannot call Anthropic. |
+| Tailoring | `ANTHROPIC_API_KEY` | The generation request fails without spending provider quota. |
+| Production public endpoints | absolute, durable `RESUME_FOUNDRY_RATE_LIMIT_DIR` | Protected public routes return `503 RATE_LIMIT_UNAVAILABLE`; the server can still render pages. |
+| Reverse-proxied Google connection controls | exact browser-visible `RESUME_FOUNDRY_PUBLIC_ORIGIN` | Same-origin disconnect validation may reject a legitimate request behind a proxy. Use `http://localhost:3000` for the documented local profile. |
+| Agent HTTP API | `RESUME_FOUNDRY_AGENT_API_TOKEN`, 32+ byte `RESUME_FOUNDRY_AGENT_AUDIT_KEY`, absolute `RESUME_FOUNDRY_AGENT_STORE` | Agent calls fail closed; the browser workshop remains separate. |
+| MCP stdio | the agent-store settings above plus `RESUME_FOUNDRY_MCP_ENABLED=true` | `npm run mcp` refuses to expose tools. The web server does not require MCP to be enabled. |
+| Employer/Gmail submission | `RESUME_FOUNDRY_HUMAN_APPROVAL_SECRET`, absolute `RESUME_FOUNDRY_SUBMISSION_LEDGER`, absolute `RESUME_FOUNDRY_NONCE_STORE`, absolute `RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR`, an exact provider allowlist, and that provider's credential | Approval or execution fails before provider transport. |
+| Windows production with any sensitive path above | `RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply` or `verify` | `npm start` exits during `prestart` instead of serving with a permissive NTFS ACL. |
+
+`RESUME_FOUNDRY_MCP_ENABLED=false` is a useful explicit default, not a requirement for the web server. `RESUME_FOUNDRY_PUBLIC_ORIGIN` is a correctness requirement for the connection mutation behind a TLS-terminating proxy, not authentication for the rest of the application.
+
+## Minimal local production profile
+
+Use a private directory outside the repository. This example enables the browser workshop and real tailoring but does not enable agents, MCP, Google, or employer submission.
+
+```dotenv
+ANTHROPIC_API_KEY=<from your secret manager>
+RESUME_FOUNDRY_PUBLIC_ORIGIN=http://localhost:3000
+RESUME_FOUNDRY_RATE_LIMIT_DIR=C:\Users\<service-user>\AppData\Local\ResumeFoundry\rate-limits
+RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply
+RESUME_FOUNDRY_MCP_ENABLED=false
+```
+
+Then run:
+
+```powershell
+npm ci
+npm test
+npm run lint
+npm run typecheck
+npm run build
+npm start -- --hostname 127.0.0.1 --port 3000
+```
+
+`apply` creates missing configured directories and replaces their ACLs with owner, Local System, and local Administrators access only. Use a dedicated service identity. After provisioning once, a locked-down deployment may switch to `verify`; it will refuse ACL drift rather than repairing it. Read [WINDOWS_STORAGE_ACL.md](WINDOWS_STORAGE_ACL.md) before using a shared volume, container mount, network share, or non-NTFS filesystem.
+
+## Full single-host capability layout
+
+Keep related state under one private durable root, but use separate files and directories. Example names—not secrets—are:
+
+```text
+ResumeFoundry\
+  agent\agent-store.json
+  limits\
+  submissions\used-approvals.jsonl
+  submissions\nonces\
+  submissions\attempts\
+```
+
+Map them to:
+
+```dotenv
+RESUME_FOUNDRY_AGENT_STORE=C:\private\ResumeFoundry\agent\agent-store.json
+RESUME_FOUNDRY_RATE_LIMIT_DIR=C:\private\ResumeFoundry\limits
+RESUME_FOUNDRY_SUBMISSION_LEDGER=C:\private\ResumeFoundry\submissions\used-approvals.jsonl
+RESUME_FOUNDRY_NONCE_STORE=C:\private\ResumeFoundry\submissions\nonces
+RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR=C:\private\ResumeFoundry\submissions\attempts
+```
+
+All Node workers on the same host must use the same durable paths. These file-backed primitives provide single-host cross-process coordination; they are not a distributed multi-host datastore.
+
+## Startup verification
+
+1. Confirm the checkout and intended build: `git status --short --branch` and `git rev-parse HEAD`.
+2. Run `npm ci`, the test/lint/typecheck gates, and `npm run build`.
+3. Run `npm start`. On Windows, expect `Windows sensitive-storage ACL check passed` before Next starts when sensitive paths are configured.
+4. Check the page and guide routes: `/`, `/how-it-works`, and `/about` must return `200`.
+5. Send a small invalid JSON object to `/api/tailor`. A normal `400` schema response proves the rate-limit store admitted the request; `503 RATE_LIMIT_UNAVAILABLE` means its directory is missing, relative, unwritable, or unsafe.
+6. Verify the process binds only to the intended interface. The local profile uses `127.0.0.1`, not `0.0.0.0`.
+7. Test only the optional capabilities you deliberately enabled. Do not infer provider readiness from unit tests with mocked transports.
+
+## Failure guide
+
+| Symptom | Meaning and action |
+|---|---|
+| `RESUME_FOUNDRY_WINDOWS_ACL_MODE=apply or verify is required` | A Windows sensitive path is configured without an ACL policy. Choose `apply` for provisioning or pre-provision the path and use `verify`; do not bypass it with `off` in production. |
+| `RATE_LIMIT_UNAVAILABLE` / `safety limit is not ready` | Set `RESUME_FOUNDRY_RATE_LIMIT_DIR` to an absolute private durable directory shared by the host's workers, then restart. |
+| `RESUME_FOUNDRY_AGENT_AUDIT_KEY must contain at least 32 bytes` | Inject a separate 32+ byte audit key. Do not reuse the API bearer token or place the value in Git. |
+| `RESUME_FOUNDRY_NONCE_STORE must be configured` | Submission/attestation replay protection has no durable store. Configure its absolute shared directory before enabling that operation. |
+| `RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR must be configured` | Provider attempt state cannot be made durable. Configure it; never substitute an in-memory fallback. |
+| MCP refuses to start | This is expected until `RESUME_FOUNDRY_MCP_ENABLED=true`. Enable it only for a trusted local process boundary. |
+| Google disconnect returns `403` behind a proxy | Set `RESUME_FOUNDRY_PUBLIC_ORIGIN` to the exact external origin, including scheme and non-default port. |
+
+## What this runbook does not prove
+
+Successful startup proves only that local prerequisites passed. It does not prove a real Anthropic request, OAuth exchange, email draft, employer API contract, multi-host correctness, backup recovery, monitoring, or public multi-user readiness. Capture those as separate credentialed acceptance evidence and never submit a real employment application as a deployment smoke test.

--- a/docs/WINDOWS_STORAGE_ACL.md
+++ b/docs/WINDOWS_STORAGE_ACL.md
@@ -14,6 +14,7 @@ The boundary recognizes these paths:
 
 - `RESUME_FOUNDRY_AGENT_STORE` (file; its containing directory is secured)
 - `RESUME_FOUNDRY_SUBMISSION_LEDGER` (file; its containing directory is secured)
+- `RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR` (directory)
 - `RESUME_FOUNDRY_NONCE_STORE` (directory)
 - `RESUME_FOUNDRY_RATE_LIMIT_DIR` (directory)
 - `RESUME_FOUNDRY_AUDIT_STORE` (file; its containing directory is secured)

--- a/lib/deployment-runbook.test.ts
+++ b/lib/deployment-runbook.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const root = new URL("../", import.meta.url);
+const read = (name: string) => readFileSync(new URL(name, root), "utf8");
+
+const operationalVariables = [
+  "RESUME_FOUNDRY_AGENT_AUDIT_KEY",
+  "RESUME_FOUNDRY_WINDOWS_ACL_MODE",
+  "RESUME_FOUNDRY_RATE_LIMIT_DIR",
+  "RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR",
+  "RESUME_FOUNDRY_NONCE_STORE",
+  "RESUME_FOUNDRY_PUBLIC_ORIGIN",
+  "RESUME_FOUNDRY_MCP_ENABLED",
+] as const;
+
+describe("deployment documentation", () => {
+  it("documents every fail-closed operational variable in the example and runbook", () => {
+    const example = read(".env.example");
+    const runbook = read("docs/DEPLOYMENT.md");
+    for (const variable of operationalVariables) {
+      expect(example, `${variable} missing from .env.example`).toContain(variable);
+      expect(runbook, `${variable} missing from deployment runbook`).toContain(variable);
+    }
+  });
+
+  it("links the runbook from the quick start and does not claim the API key is the only production requirement", () => {
+    const readme = read("README.md");
+    expect(readme).toContain("docs/DEPLOYMENT.md");
+    expect(readme).not.toMatch(/only required variable is `ANTHROPIC_API_KEY`/i);
+  });
+
+  it("keeps the Windows ACL inventory aligned with the submission attempt store", () => {
+    expect(read("docs/WINDOWS_STORAGE_ACL.md")).toContain("RESUME_FOUNDRY_SUBMISSION_ATTEMPT_DIR");
+  });
+});


### PR DESCRIPTION
## What changed
- adds an authoritative deployment runbook organized by capability profile
- documents required rate-limit, audit, ACL, nonce, submission-attempt, origin, and MCP settings
- adds minimal Windows production setup, startup verification, and failure diagnosis
- fills missing nonce-store and ACL variables in .env.example
- corrects the README claim that the Anthropic API key is the only production requirement
- adds regression tests preventing the operational variables and ACL inventory from drifting out of the docs

## Why
The hardened application correctly fails closed, but operators could reasonably interpret missing deployment prerequisites as a broken build. This makes the secure startup contract explicit without weakening any guard.

## Validation
- 343/343 tests
- lint
- typecheck
- production build