### PR TITLE
Strip unsupported Anthropic schema bounds

### DIFF
--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -392,6 +392,15 @@ describe("deterministic evidence boundary", () => {
 });
 
 describe("tailorResultJsonSchema", () => {
+  it("omits provider-unsupported array bounds while retaining runtime caps", () => {
+    const schema = tailorResultJsonSchema();
+    expect(JSON.stringify(schema)).not.toMatch(/"(?:minItems|maxItems)"/u);
+    const tooMany = Array.from({ length: 101 }, (_, index) => ({
+      id: `r-${index}`, requirement: "Requirement", category: "mandatory" as const,
+      state: "proven" as const, evidence: ["Evidence"], tailoredText: ["Evidence"], recommendation: "",
+    }));
+    expect(() => TailorResultSchema.parse({ ...VALID_RESULT, requirement_evidence: tooMany })).toThrow();
+  });
   it("emits additionalProperties:false on every object (structured-output requirement)", () => {
     const schema = tailorResultJsonSchema();
     const objects: Record<string, unknown>[] = [];

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -316,6 +316,10 @@ export function tailorResultJsonSchema(): Record<string, unknown> {
     delete n.maximum;
     delete n.exclusiveMinimum;
     delete n.exclusiveMaximum;
+    // Anthropic structured outputs reject array cardinality keywords even
+    // though Zod must retain them for post-response workload limits.
+    delete n.minItems;
+    delete n.maxItems;
     for (const v of Object.values(n)) strip(v);
   };
   strip(schema);


### PR DESCRIPTION
Keeps Zod runtime workload caps while removing provider-unsupported minItems/maxItems from the generated structured-output schema. Reproduced against the live Anthropic API, which rejected maxItems before generation. Adds a regression proving provider schema omission and runtime enforcement.\n\nEvidence: 518/518 tests, lint, typecheck, build, npm audit 0.