### PR TITLE
Reconcile generated output metadata

### DIFF
--- a/app/api/tailor/route.ts
+++ b/app/api/tailor/route.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/prompts";
-import { assertTailorResultEvidence, HonestyValidationError, summarizeHonestyViolations, TailorRequestSchema, TailorResultSchema, tailorResultJsonSchema } from "@/lib/schema";
+import { assertTailorResultEvidence, HonestyValidationError, reconcileTailorResultOutputReferences, summarizeHonestyViolations, TailorRequestSchema, TailorResultSchema, tailorResultJsonSchema } from "@/lib/schema";
 import { HttpLimitError, readJsonBody } from "@/lib/http-limits";
 import { enforcePublicRateLimit } from "@/lib/durable-rate-limit";
 import { resolveModel } from "@/lib/anthropic-model";
@@ -98,7 +98,7 @@ export async function POST(req: NextRequest): Promise<Response> {
             .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
             .map((b) => b.text)
             .join("");
-          const result = TailorResultSchema.parse(JSON.parse(text));
+          const result = reconcileTailorResultOutputReferences(TailorResultSchema.parse(JSON.parse(text)));
           assertTailorResultEvidence(result, parsed.resume);
           send({ type: "result", data: result });
         }

--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assertTailorResultEvidence,
+  reconcileTailorResultOutputReferences,
   summarizeHonestyViolations,
   TailorRequestSchema,
   TailorResultSchema,
@@ -67,6 +68,20 @@ describe("deterministic evidence boundary", () => {
     requirement_evidence: [{ id: "evidence", requirement: "Evidence", category: "mandatory", state,
       evidence: [evidence], tailoredText: ["Supported claim"], recommendation: "" }],
     tailored_resume_markdown: "# Jane Doe\nSupported claim",
+  });
+  it("reconciles output-only metadata without weakening source evidence", () => {
+    const result = TailorResultSchema.parse({
+      ...VALID_RESULT,
+      keywords: { matched: [], added: ["CI/CD", "phantom keyword"], not_added: [] },
+      requirement_evidence: [{ id: "delivery", requirement: "Delivery", category: "mandatory", state: "proven",
+        evidence: ["Built CI pipelines"], tailoredText: ["Built CI/CD pipelines", "missing output text"], recommendation: "" }],
+      tailored_resume_markdown: "# Jane Doe\nBuilt CI/CD pipelines",
+    });
+    const reconciled = reconcileTailorResultOutputReferences(result);
+    expect(reconciled.keywords.added).toEqual(["CI/CD"]);
+    expect(reconciled.keywords.not_added).toContainEqual({ keyword: "phantom keyword", reason: "Not present in the generated documents." });
+    expect(reconciled.requirement_evidence[0].tailoredText).toEqual(["Built CI/CD pipelines"]);
+    expect(() => assertTailorResultEvidence(reconciled, "Built CI pipelines")).not.toThrow();
   });
   it("accepts source-backed evidence and output references", () => {
     const result = TailorResultSchema.parse({

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -301,6 +301,28 @@ export function assertTailorResultEvidence(result: TailorResult, originalResume:
   if (violations.length) throw new HonestyValidationError([...new Set(violations)]);
 }
 
+/** Remove model-authored output metadata that is not present in the rendered documents. */
+export function reconcileTailorResultOutputReferences(result: TailorResult): TailorResult {
+  const output = comparableOutput(`${result.tailored_resume_markdown}\n${result.cover_letter_markdown}`);
+  const added = result.keywords.added.filter((keyword) => output.includes(comparableSource(keyword)));
+  const removed = result.keywords.added.filter((keyword) => !output.includes(comparableSource(keyword)));
+  return {
+    ...result,
+    keywords: {
+      ...result.keywords,
+      added,
+      not_added: [
+        ...result.keywords.not_added,
+        ...removed.map((keyword) => ({ keyword, reason: "Not present in the generated documents." })),
+      ],
+    },
+    requirement_evidence: result.requirement_evidence.map((requirement) => ({
+      ...requirement,
+      tailoredText: requirement.tailoredText.filter((text) => output.includes(comparableSource(text))),
+    })),
+  };
+}
+
 /**
  * JSON schema for the Claude structured-output format:
  * additionalProperties:false everywhere, and no numeric constraints


### PR DESCRIPTION
Semantic policy change: source-citation mismatches remain fail-closed and can withhold a draft. Model-authored tailoredText and keywords.added claims are corrected before validation rather than enforced as rejection gates: missing tailoredText references are removed, and missing added-keyword claims move to not_added with a system-generated reason. This keeps source-evidence honesty strict while preserving an otherwise valid draft. The resulting tailoredText audit linkage is best-effort and may be empty for a supported requirement.

Live evidence: real Anthropic request returned a result after this correction path. Gates at merge: 519 tests, lint, typecheck, build, audit 0.