### PR TITLE
Document honesty correction boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The 2026 market splits into distrusted black-box scorers, keyword-overlap tracke
 - **Job by URL** — paste a public careers-page link and a bounded HTML response is fetched and extracted server-side. LinkedIn and Indeed automation is rejected; paste those postings manually.
 - **Instant keyword scan** — deterministic, client-side coverage check the moment both fields are filled. Transparent baseline before the AI pass.
 - **AI tailoring** — streaming analysis you can watch live, then: before/after match scores with rationale, classified change log, matched / honestly-added / not-added keywords, gap analysis with concrete advice, and ATS formatting checks.
+- **Honesty enforcement boundary** — source citations are checked against the supplied résumé and a mismatch withholds the draft. Model-authored `tailoredText` and `keywords.added` references are corrected, not rejection gates: missing output references are removed, missing added-keyword claims move to `not_added` with a system-attributed reason, and `tailoredText` linkage is therefore best-effort. Human review remains required.
 - **Cover letter** — specific to your evidence and the posting, never generic filler.
 - **Exports** — DOCX (ATS-safe single column), Markdown, plain text, print/PDF, one-click copy.
 - **History** — past runs stored locally, reloadable, deletable.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -315,10 +315,10 @@ export default function Home() {
           else if (event.type === "error") {
             if (event.reasonCode === "EVIDENCE_VALIDATION_FAILED") {
               const blockedReferences = event.validation
-                ? Object.values(event.validation).reduce((total, count) => total + count, 0)
+                ? event.validation.sourceCitationMismatch
                 : 0;
               const detail = blockedReferences > 0
-                ? ` ${blockedReferences} evidence reference${blockedReferences === 1 ? "" : "s"} could not be verified.`
+                ? ` ${blockedReferences} source citation${blockedReferences === 1 ? "" : "s"} could not be verified.`
                 : "";
               throw new Error(`${event.message}${detail}`);
             }

--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -79,7 +79,10 @@ describe("deterministic evidence boundary", () => {
     });
     const reconciled = reconcileTailorResultOutputReferences(result);
     expect(reconciled.keywords.added).toEqual(["CI/CD"]);
-    expect(reconciled.keywords.not_added).toContainEqual({ keyword: "phantom keyword", reason: "Not present in the generated documents." });
+    expect(reconciled.keywords.not_added).toContainEqual({
+      keyword: "phantom keyword",
+      reason: "System correction: the model listed this keyword as added, but it was not present in the generated documents.",
+    });
     expect(reconciled.requirement_evidence[0].tailoredText).toEqual(["Built CI/CD pipelines"]);
     expect(() => assertTailorResultEvidence(reconciled, "Built CI pipelines")).not.toThrow();
   });

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -12,7 +12,7 @@ export const RequirementEvidenceSchema = z.strictObject({
   category: z.enum(["mandatory", "preferred", "responsibility", "logistics"]),
   state: EvidenceStateSchema,
   evidence: z.array(z.string().max(2_000)).max(10).describe("Exact facts from the original resume supporting this requirement; empty when unsupported"),
-  tailoredText: z.array(z.string().max(2_000)).max(20).describe("Exact resulting resume or cover-letter text tied to this requirement; empty when unsupported"),
+  tailoredText: z.array(z.string().max(2_000)).max(20).describe("Best-effort exact output spans tied to this requirement; invalid model references are removed and may leave this empty"),
   recommendation: z.string().describe("Honest next step, clarification, adjacent skill, portfolio task, training, or omission rationale"),
 }).superRefine((item, context) => {
   if (item.state === "unsupported" && (item.evidence.length > 0 || item.tailoredText.length > 0)) {
@@ -313,7 +313,7 @@ export function reconcileTailorResultOutputReferences(result: TailorResult): Tai
       added,
       not_added: [
         ...result.keywords.not_added,
-        ...removed.map((keyword) => ({ keyword, reason: "Not present in the generated documents." })),
+        ...removed.map((keyword) => ({ keyword, reason: "System correction: the model listed this keyword as added, but it was not present in the generated documents." })),
       ],
     },
     requirement_evidence: result.requirement_evidence.map((requirement) => ({
@@ -338,8 +338,9 @@ export function tailorResultJsonSchema(): Record<string, unknown> {
     delete n.maximum;
     delete n.exclusiveMinimum;
     delete n.exclusiveMaximum;
-    // Anthropic structured outputs reject array cardinality keywords even
-    // though Zod must retain them for post-response workload limits.
+    // Live Anthropic verification accepts $schema/minLength/maxLength but
+    // rejects array cardinality keywords. Zod retains the latter for
+    // post-response workload limits; only the provider schema omits them.
     delete n.minItems;
     delete n.maxItems;
     for (const v of Object.values(n)) strip(v);


### PR DESCRIPTION
Documents the semantic policy introduced by PR58: source-citation mismatches remain fail-closed, while invalid model-authored tailoredText and added-keyword output references are corrected rather than used as rejection gates. Labels system-authored not_added reasons explicitly, describes tailoredText linkage as best-effort, and ensures the UI reports only reachable source-citation failures. Also records the empirically verified Anthropic schema-keyword boundary.